### PR TITLE
25 feat: add ensure color mode to vision module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,7 @@ fenn = "fenn.cli:main"
 "Documentation" = "https://pyfenn.org"
 "Source Code" = "https://github.com/blkdmr/fenn"
 "Bug Tracker" = "https://github.com/blkdmr/fenn/issues"
+
+[tool.pytest.ini_options]
+testpaths = ["src/tests"]
+norecursedirs = ["tests", "venv", ".venv", "__pycache__", "*.egg"]

--- a/src/fenn/vision/__init__.py
+++ b/src/fenn/vision/__init__.py
@@ -1,1 +1,2 @@
 from fenn.vision.summary import image_summary
+from fenn.vision.color_mode import ensure_color_mode

--- a/src/fenn/vision/color_mode.py
+++ b/src/fenn/vision/color_mode.py
@@ -1,0 +1,242 @@
+import numpy as np
+from typing import Literal
+
+from fenn.vision.vision_utils import detect_format
+
+
+def _gray_to_rgb(
+    array: np.ndarray,
+    channel_location: Literal["first", "last"] | None,
+) -> np.ndarray:
+    """
+    Convert grayscale array to RGB by duplicating the channel.
+
+    Args:
+        array: Grayscale image array with batch dimension
+        channel_location: Channel position ("first", "last", or None)
+
+    Returns:
+        RGB array with 3 channels
+    """
+    if channel_location is None:
+        # (N, H, W) - no channel dimension → (N, H, W, 3) with channels last
+        return np.stack([array, array, array], axis=-1)
+    elif channel_location == "last":
+        # (N, H, W, 1) - channels last → (N, H, W, 3)
+        return np.repeat(array, 3, axis=-1)
+    else:  # channel_location == "first"
+        # (N, 1, H, W) - channels first → (N, 3, H, W)
+        return np.repeat(array, 3, axis=1)
+
+
+def _rgb_to_rgba(
+    array: np.ndarray,
+    channel_location: Literal["first", "last"],
+) -> np.ndarray:
+    """
+    Convert RGB array to RGBA by adding alpha channel with full opacity.
+
+    Args:
+        array: RGB image array with batch dimension
+        channel_location: Channel position ("first" or "last")
+
+    Returns:
+        RGBA array with 4 channels
+    """
+    # Get alpha value for dtype (full opacity)
+    if array.dtype == np.uint8:
+        alpha_value = 255
+    elif array.dtype.kind == 'f':  # float
+        alpha_value = 1.0
+    else:
+        alpha_value = np.iinfo(array.dtype).max
+
+    if channel_location == "last":
+        # (N, H, W, 3) → (N, H, W, 4)
+        alpha = np.full((*array.shape[:-1], 1), alpha_value, dtype=array.dtype)
+        return np.concatenate([array, alpha], axis=-1)
+    else:  # channel_location == "first"
+        # (N, 3, H, W) → (N, 4, H, W)
+        alpha = np.full((array.shape[0], 1, *array.shape[2:]), alpha_value, dtype=array.dtype)
+        return np.concatenate([array, alpha], axis=1)
+
+
+def _rgba_to_rgb(
+    array: np.ndarray,
+    channel_location: Literal["first", "last"],
+) -> np.ndarray:
+    """
+    Convert RGBA array to RGB by dropping alpha channel.
+
+    Args:
+        array: RGBA image array with batch dimension
+        channel_location: Channel position ("first" or "last")
+
+    Returns:
+        RGB array with 3 channels
+    """
+    if channel_location == "last":
+        # (N, H, W, 4) → (N, H, W, 3)
+        return array[..., :3]
+    else:  # channel_location == "first"
+        # (N, 4, H, W) → (N, 3, H, W)
+        return array[:, :3, ...]
+
+
+def _rgb_to_gray(
+    array: np.ndarray,
+    channel_location: Literal["first", "last"],
+) -> np.ndarray:
+    """
+    Convert RGB array to grayscale using standard luminance weights.
+
+    Uses ITU-R BT.601 weights: 0.299*R + 0.587*G + 0.114*B
+
+    Args:
+        array: RGB image array with batch dimension
+        channel_location: Channel position ("first" or "last")
+
+    Returns:
+        Grayscale array with 1 channel (or no channel dimension if channels were last)
+    """
+    weights = np.array([0.299, 0.587, 0.114], dtype=np.float32)
+
+    if channel_location == "last":
+        # (N, H, W, 3) → (N, H, W)
+        gray_float = np.sum(array.astype(np.float32) * weights, axis=-1)
+        return gray_float.astype(array.dtype)
+    else:  # channel_location == "first"
+        # (N, 3, H, W) → (N, H, W)
+        weights_reshaped = weights.reshape(3, 1, 1)
+        gray_float = np.sum(array.astype(np.float32) * weights_reshaped, axis=1)
+        return gray_float.astype(array.dtype)
+
+
+def _convert_color_mode(
+    array: np.ndarray,
+    current_mode: str,
+    target_mode: str,
+    channel_location: Literal["first", "last"] | None,
+) -> np.ndarray:
+    """
+    Convert array from current_mode to target_mode.
+
+    Args:
+        array: Input image array with batch dimension
+        current_mode: Current color mode ("GRAY", "RGB", or "RGBA")
+        target_mode: Target color mode ("GRAY", "RGB", or "RGBA")
+        channel_location: Channel position ("first", "last", or None)
+
+    Returns:
+        Converted array in target mode
+    """
+    # Safety check: if already in target mode, return a copy
+    if current_mode == target_mode:
+        return array.copy()
+
+    # Perform conversions using helper functions
+    if current_mode == "GRAY":
+        if target_mode == "RGB":
+            return _gray_to_rgb(array, channel_location)
+        else:  # target_mode == "RGBA"
+            rgb = _gray_to_rgb(array, channel_location)
+            effective_channel_location = channel_location if channel_location is not None else "last"
+            return _rgb_to_rgba(rgb, effective_channel_location)
+
+    elif current_mode == "RGB":
+        if target_mode == "GRAY":
+            return _rgb_to_gray(array, channel_location)
+        else:  # target_mode == "RGBA"
+            return _rgb_to_rgba(array, channel_location)
+
+    else:  # current_mode == "RGBA"
+        if target_mode == "RGB":
+            return _rgba_to_rgb(array, channel_location)
+        else:  # target_mode == "GRAY"
+            rgb = _rgba_to_rgb(array, channel_location)
+            return _rgb_to_gray(rgb, channel_location)
+
+
+def ensure_color_mode(array: np.ndarray, mode: str = "RGB") -> np.ndarray:
+    """
+    Convert grayscale / RGB / RGBA images to the desired channel layout.
+    
+    Converts NumPy image arrays to the specified color mode by:
+    - Expanding grayscale images to 3 channels (e.g., for RGB mode)
+    - Dropping alpha channel (e.g., converting RGBA to RGB)
+    - Preserving the original channel layout (first or last)
+
+    Args:
+        array: Input image array with batch dimension. Must be:
+            - (N, H, W) - batch of grayscale images
+            - (N, H, W, C) - batch with channels last
+            - (N, C, H, W) - batch with channels first
+        mode: Target color mode. Supported modes:
+            - "RGB" - 3 channels (default)
+            - "RGBA" - 4 channels with alpha
+            - "L" or "GRAY" - 1 channel grayscale
+
+    Returns:
+        Array converted to the specified color mode, preserving:
+            - Original dtype
+            - Original channel layout (first or last)
+            - Batch dimension
+
+    Raises:
+        TypeError: If array is not a numpy array
+        ValueError: If mode is not supported or array format is invalid
+
+    Example:
+        >>> import numpy as np
+        >>> # Convert grayscale to RGB
+        >>> gray_batch = np.random.randint(0, 255, (10, 224, 224), dtype=np.uint8)
+        >>> rgb = ensure_color_mode(gray_batch, mode="RGB")
+        >>> print(rgb.shape)  # (10, 224, 224, 3)
+    """
+    if not isinstance(array, np.ndarray):
+        raise TypeError(f"Expected numpy.ndarray, got {type(array)}")
+
+    # Validate target mode    
+    target_mode = mode.upper()
+    supported_modes = {"RGB", "RGBA", "L", "GRAY"}
+    if target_mode not in supported_modes:
+        raise ValueError(
+            f"Unsupported mode '{target_mode}'. Supported modes: {supported_modes}"
+        )
+    if target_mode == "L":
+        target_mode = "GRAY"
+
+    format_info = detect_format(array)
+    is_grayscale = format_info["is_grayscale"]
+    channel_location: Literal["first", "last"] | None = format_info["channel_location"]
+
+    # Determine current channel count and mode
+    if is_grayscale:
+        current_channels = 1
+        current_mode = "GRAY"
+    else:
+        if channel_location == "last":
+            current_channels = array.shape[3]
+        elif channel_location == "first":
+            current_channels = array.shape[1]
+        else:
+            # This should never happen - non-grayscale images must have channel_location
+            raise ValueError(
+                f"Invalid format: non-grayscale image with channel_location={channel_location}. "
+                f"This indicates a bug in detect_format or unexpected array format."
+            )
+
+        if current_channels == 1:
+            current_mode = "GRAY"
+        elif current_channels == 3:
+            current_mode = "RGB"
+        elif current_channels == 4:
+            current_mode = "RGBA"
+        else:
+            raise ValueError(
+                f"Unsupported channel count: {current_channels}. "
+                f"Expected 1 (grayscale), 3 (RGB), or 4 (RGBA)."
+            )
+
+    # Convert using helper function
+    return _convert_color_mode(array, current_mode, target_mode, channel_location)

--- a/src/tests/vision/test_color_mode.py
+++ b/src/tests/vision/test_color_mode.py
@@ -1,0 +1,204 @@
+import pytest
+import numpy as np
+
+from fenn.vision.color_mode import ensure_color_mode
+
+
+class TestEnsureColorMode:
+    """Test suite for ensure_color_mode function."""
+
+    def test_gray_to_rgb_channels_last(self):
+        """Test GRAY → RGB conversion with channels last."""
+        gray = np.random.randint(0, 255, (10, 224, 224), dtype=np.uint8)
+        rgb = ensure_color_mode(gray, mode="RGB")
+        
+        assert rgb.shape == (10, 224, 224, 3)
+        assert rgb.dtype == gray.dtype
+        # All channels should be identical
+        np.testing.assert_array_equal(rgb[:, :, :, 0], gray)
+        np.testing.assert_array_equal(rgb[:, :, :, 1], gray)
+        np.testing.assert_array_equal(rgb[:, :, :, 2], gray)
+
+    def test_gray_to_rgb_channels_first(self):
+        """Test GRAY → RGB conversion with channels first."""
+        gray = np.random.randint(0, 255, (10, 1, 224, 224), dtype=np.uint8)
+        rgb = ensure_color_mode(gray, mode="RGB")
+        
+        assert rgb.shape == (10, 3, 224, 224)
+        assert rgb.dtype == gray.dtype
+        # All channels should be identical
+        np.testing.assert_array_equal(rgb[:, 0, :, :], gray[:, 0, :, :])
+        np.testing.assert_array_equal(rgb[:, 1, :, :], gray[:, 0, :, :])
+        np.testing.assert_array_equal(rgb[:, 2, :, :], gray[:, 0, :, :])
+
+    def test_gray_to_rgba_channels_last(self):
+        """Test GRAY → RGBA conversion with channels last."""
+        gray = np.random.randint(0, 255, (10, 224, 224), dtype=np.uint8)
+        rgba = ensure_color_mode(gray, mode="RGBA")
+        
+        assert rgba.shape == (10, 224, 224, 4)
+        assert rgba.dtype == gray.dtype
+        # RGB channels should be identical
+        np.testing.assert_array_equal(rgba[:, :, :, 0], gray)
+        np.testing.assert_array_equal(rgba[:, :, :, 1], gray)
+        np.testing.assert_array_equal(rgba[:, :, :, 2], gray)
+        # Alpha should be 255 (full opacity for uint8)
+        assert np.all(rgba[:, :, :, 3] == 255)
+
+    def test_rgb_to_gray_channels_last(self):
+        """Test RGB → GRAY conversion with channels last."""
+        rgb = np.random.randint(0, 255, (10, 224, 224, 3), dtype=np.uint8)
+        gray = ensure_color_mode(rgb, mode="GRAY")
+        
+        assert gray.shape == (10, 224, 224)
+        assert gray.dtype == rgb.dtype
+        # Grayscale should be weighted average
+        expected = (rgb[:, :, :, 0] * 0.299 + rgb[:, :, :, 1] * 0.587 + rgb[:, :, :, 2] * 0.114).astype(np.uint8)
+        np.testing.assert_array_almost_equal(gray, expected, decimal=0)
+
+    def test_rgb_to_gray_channels_first(self):
+        """Test RGB → GRAY conversion with channels first."""
+        rgb = np.random.randint(0, 255, (10, 3, 224, 224), dtype=np.uint8)
+        gray = ensure_color_mode(rgb, mode="GRAY")
+        
+        assert gray.shape == (10, 224, 224)
+        assert gray.dtype == rgb.dtype
+
+    def test_rgb_to_rgba_channels_last(self):
+        """Test RGB → RGBA conversion with channels last."""
+        rgb = np.random.randint(0, 255, (10, 224, 224, 3), dtype=np.uint8)
+        rgba = ensure_color_mode(rgb, mode="RGBA")
+        
+        assert rgba.shape == (10, 224, 224, 4)
+        assert rgba.dtype == rgb.dtype
+        # RGB channels should be preserved
+        np.testing.assert_array_equal(rgba[:, :, :, :3], rgb)
+        # Alpha should be 255
+        assert np.all(rgba[:, :, :, 3] == 255)
+
+    def test_rgba_to_rgb_channels_last(self):
+        """Test RGBA → RGB conversion with channels last."""
+        rgba = np.random.randint(0, 255, (10, 224, 224, 4), dtype=np.uint8)
+        rgb = ensure_color_mode(rgba, mode="RGB")
+        
+        assert rgb.shape == (10, 224, 224, 3)
+        assert rgb.dtype == rgba.dtype
+        # RGB channels should be preserved
+        np.testing.assert_array_equal(rgb, rgba[:, :, :, :3])
+
+    def test_rgba_to_gray_channels_last(self):
+        """Test RGBA → GRAY conversion with channels last."""
+        rgba = np.random.randint(0, 255, (10, 224, 224, 4), dtype=np.uint8)
+        gray = ensure_color_mode(rgba, mode="GRAY")
+        
+        assert gray.shape == (10, 224, 224)
+        assert gray.dtype == rgba.dtype
+        # Should match RGB → GRAY conversion
+        rgb = rgba[:, :, :, :3]
+        expected = (rgb[:, :, :, 0] * 0.299 + rgb[:, :, :, 1] * 0.587 + rgb[:, :, :, 2] * 0.114).astype(np.uint8)
+        np.testing.assert_array_almost_equal(gray, expected, decimal=0)
+
+    def test_no_op_rgb(self):
+        """Test that RGB → RGB returns a copy."""
+        rgb = np.random.randint(0, 255, (10, 224, 224, 3), dtype=np.uint8)
+        result = ensure_color_mode(rgb, mode="RGB")
+        
+        assert result.shape == rgb.shape
+        assert result.dtype == rgb.dtype
+        np.testing.assert_array_equal(result, rgb)
+        # Should be a copy, not the same array
+        assert result is not rgb
+
+    def test_no_op_rgba(self):
+        """Test that RGBA → RGBA returns a copy."""
+        rgba = np.random.randint(0, 255, (10, 224, 224, 4), dtype=np.uint8)
+        result = ensure_color_mode(rgba, mode="RGBA")
+        
+        assert result.shape == rgba.shape
+        assert result.dtype == rgba.dtype
+        np.testing.assert_array_equal(result, rgba)
+        assert result is not rgba
+
+    def test_no_op_gray(self):
+        """Test that GRAY → GRAY returns a copy."""
+        gray = np.random.randint(0, 255, (10, 224, 224), dtype=np.uint8)
+        result = ensure_color_mode(gray, mode="GRAY")
+        
+        assert result.shape == gray.shape
+        assert result.dtype == gray.dtype
+        np.testing.assert_array_equal(result, gray)
+        assert result is not gray
+
+    def test_mode_alias_l_to_gray(self):
+        """Test that 'L' mode is normalized to 'GRAY'."""
+        gray = np.random.randint(0, 255, (10, 224, 224), dtype=np.uint8)
+        result_l = ensure_color_mode(gray, mode="L")
+        result_gray = ensure_color_mode(gray, mode="GRAY")
+        
+        np.testing.assert_array_equal(result_l, result_gray)
+
+    def test_float_dtype(self):
+        """Test conversion with float dtype."""
+        rgb = np.random.rand(10, 224, 224, 3).astype(np.float32)
+        rgba = ensure_color_mode(rgb, mode="RGBA")
+        
+        assert rgba.shape == (10, 224, 224, 4)
+        assert rgba.dtype == rgb.dtype
+        # Alpha should be 1.0 for float
+        assert np.allclose(rgba[:, :, :, 3], 1.0)
+
+    def test_invalid_mode_raises_error(self):
+        """Test that invalid mode raises ValueError."""
+        rgb = np.random.randint(0, 255, (10, 224, 224, 3), dtype=np.uint8)
+        
+        with pytest.raises(ValueError) as exc_info:
+            ensure_color_mode(rgb, mode="INVALID")
+        
+        assert "Unsupported mode" in str(exc_info.value)
+
+    def test_non_numpy_array_raises_error(self):
+        """Test that non-numpy array raises TypeError."""
+        with pytest.raises(TypeError) as exc_info:
+            ensure_color_mode([1, 2, 3], mode="RGB")
+        
+        assert "numpy.ndarray" in str(exc_info.value)
+
+    def test_preserves_dtype(self):
+        """Test that dtype is preserved through conversions."""
+        gray = np.random.randint(0, 255, (10, 224, 224), dtype=np.uint16)
+        rgb = ensure_color_mode(gray, mode="RGB")
+        
+        assert rgb.dtype == gray.dtype
+
+    def test_gray_to_rgba_to_gray_round_trip(self):
+        """Test property-based round-trip: GRAY → RGBA → GRAY preserves values."""
+        # Create grayscale image
+        gray_original = np.random.randint(0, 255, (10, 224, 224), dtype=np.uint8)
+        
+        # Convert to RGBA
+        rgba = ensure_color_mode(gray_original, mode="RGBA")
+        assert rgba.shape == (10, 224, 224, 4)
+        
+        # Convert back to GRAY
+        gray_restored = ensure_color_mode(rgba, mode="GRAY")
+        assert gray_restored.shape == gray_original.shape
+        
+        # Values should be preserved (within rounding tolerance for grayscale conversion)
+        np.testing.assert_array_almost_equal(gray_restored, gray_original, decimal=0)
+
+    def test_dtype_int16(self):
+        """Test conversion with int16 dtype."""
+        gray = np.random.randint(0, 32767, (10, 224, 224), dtype=np.int16)
+        rgb = ensure_color_mode(gray, mode="RGB")
+        
+        assert rgb.shape == (10, 224, 224, 3)
+        assert rgb.dtype == gray.dtype
+        # All channels should be identical
+        np.testing.assert_array_equal(rgb[:, :, :, 0], gray)
+        
+        # Test RGBA conversion
+        rgba = ensure_color_mode(rgb, mode="RGBA")
+        assert rgba.shape == (10, 224, 224, 4)
+        assert rgba.dtype == rgb.dtype
+        # Alpha should be max value for int16
+        assert np.all(rgba[:, :, :, 3] == np.iinfo(np.int16).max)


### PR DESCRIPTION
This Pr adds another function to the vision module to ensure the color mode on a batch of images. This function allows conversion between gray/rgb/rgba image batches and should preserve the dtype and channel location.

I converted color to grayscale based on CCIR 601 (Y = 0.299*R + 0.587*G + 0.114*B). When converting to RGBA alpha is set to the max for the dtype.