### PR TITLE
25 feat: add resize batch to the vision module

### DIFF
--- a/src/fenn/vision/__init__.py
+++ b/src/fenn/vision/__init__.py
@@ -1,2 +1,3 @@
 from fenn.vision.summary import image_summary
 from fenn.vision.color_mode import ensure_color_mode
+from fenn.vision.resize import resize_batch

--- a/src/fenn/vision/resize.py
+++ b/src/fenn/vision/resize.py
@@ -1,0 +1,179 @@
+import numpy as np
+from typing import Tuple, Union
+
+try:
+    import torch
+    from torchvision.transforms import functional as F
+    TORCHVISION_AVAILABLE = True
+except ImportError:
+    TORCHVISION_AVAILABLE = False
+
+from fenn.vision.vision_utils import detect_format
+
+
+def resize_batch(
+    array: np.ndarray,
+    size: Union[int, Tuple[int, int]],
+    interpolation: str = "bilinear"
+) -> np.ndarray:
+    """
+    Resize a batch of images to a target size, preserving channel order and dtype where possible.
+
+    Convenience wrapper to resize a batch of images to a uniform target size. The function
+    detects the input format (channels first/last, grayscale/color) and preserves
+    the same format in the output. Dtype is preserved where possible.
+
+    Args:
+        array: Input image array with batch dimension. Must be 3D or 4D:
+            - (N, H, W) - batch of grayscale images
+            - (N, H, W, C) - batch with channels last
+            - (N, C, H, W) - batch with channels first
+
+        size: Target size for resizing. Can be:
+            - int: Single value for both height and width (square output)
+            - Tuple[int, int]: (height, width) for rectangular output
+
+        interpolation: Interpolation method to use. Default is "bilinear".
+            Supported methods: "nearest", "nearest_exact", "bilinear", "bicubic"
+
+    Returns:
+        Resized image array with the same:
+            - Batch size (N)
+            - Channel order (first/last/none)
+            - Dtype (where possible)
+            - Shape: (N, size[0], size[1]) for grayscale or
+                     (N, size[0], size[1], C) / (N, C, size[0], size[1]) for color
+
+    Raises:
+        TypeError: If array is not a numpy array
+        ValueError: If array doesn't have batch dimension, has unsupported format,
+                    or size is invalid
+        ImportError: If torchvision is not installed (required for resizing)
+
+    Example:
+        >>> import numpy as np
+        >>> from fenn.vision import resize_batch
+        >>> # Batch of color images with channels last
+        >>> images = np.random.randint(0, 255, (32, 224, 224, 3), dtype=np.uint8)
+        >>> resized = resize_batch(images, (128, 128))
+        >>> print(resized.shape)  # (32, 128, 128, 3)
+    """
+    if not isinstance(array, np.ndarray):
+        raise TypeError(f"Expected numpy.ndarray, got {type(array)}")
+
+    # Validate size parameter
+    if isinstance(size, int):
+        target_height, target_width = size, size
+    elif isinstance(size, tuple) and len(size) == 2:
+        target_height, target_width = size
+    else:
+        raise ValueError(
+            f"size must be an int or tuple of (height, width), got {type(size)}"
+        )
+
+    if target_height <= 0 or target_width <= 0:
+        raise ValueError(
+            f"size dimensions must be positive, got ({target_height}, {target_width})"
+        )
+
+    # Detect format to preserve channel order
+    format_info = detect_format(array)
+    channel_location = format_info["channel_location"]
+
+    # Validate interpolation method
+    valid_interpolations = ["nearest", "nearest_exact", "bilinear", "bicubic"]
+    if interpolation not in valid_interpolations:
+        raise ValueError(
+            f"interpolation must be one of {valid_interpolations}, got '{interpolation}'"
+        )
+
+    if not TORCHVISION_AVAILABLE:
+        raise ImportError(
+            "torchvision is required for resize_batch. "
+            "Install it with: pip install fenn[torch] or pip install torchvision"
+        )
+
+    interpolation_map = {
+        "nearest": F.InterpolationMode.NEAREST,
+        "nearest_exact": F.InterpolationMode.NEAREST_EXACT,
+        "bilinear": F.InterpolationMode.BILINEAR,
+        "bicubic": F.InterpolationMode.BICUBIC,
+    }
+    torch_interpolation = interpolation_map[interpolation]
+
+    # Store original dtype and shape info
+    original_dtype = array.dtype
+    batch_size = array.shape[0]
+
+    # Get determine whether we are downsampling
+    if channel_location == "last":
+        # (N, H, W, C)
+        original_height, original_width = array.shape[1], array.shape[2]
+    elif channel_location == "first":
+        # (N, C, H, W)
+        original_height, original_width = array.shape[2], array.shape[3]
+    else:
+        # (N, H, W)
+        original_height, original_width = array.shape[1], array.shape[2]
+    is_downsampling = (original_height > target_height) or (original_width > target_width)
+
+    # Normalize to channels-first format (N, C, H, W) for torchvision
+    if channel_location == "last":
+        # (N, H, W, C) -> (N, C, H, W)
+        array = np.transpose(array, (0, 3, 1, 2))
+    elif channel_location is None:
+        # (N, H, W) -> (N, 1, H, W) for grayscale
+        array = array[:, np.newaxis, :, :]
+
+    # Convert to torch tensor
+    if original_dtype == np.uint8:
+        # Use uint8 directly - torchvision supports it natively
+        tensor = torch.from_numpy(array.astype(np.uint8))
+        needs_normalization = False
+    elif np.issubdtype(original_dtype, np.floating):
+        # Float arrays: assume [0, 1] range, convert to float32
+        tensor = torch.from_numpy(array.astype(np.float32))
+        needs_normalization = False
+    else:
+        # Other integer types: convert to float32 and normalize to [0, 1]
+        tensor = torch.from_numpy(array.astype(np.float32))
+        max_val = float(np.iinfo(original_dtype).max)
+        tensor = tensor / max_val
+        needs_normalization = True
+
+    # Enable antialiasing only when downsampling with smooth interpolation methods
+    use_antialias = (
+        is_downsampling and
+        interpolation in ["bilinear", "bicubic"]
+    )
+
+    # Resize using torchvision
+    resized_tensor = F.resize(
+        tensor,
+        size=[target_height, target_width],
+        interpolation=torch_interpolation,
+        antialias=use_antialias
+    )
+
+    # Convert back to numpy
+    result = resized_tensor.numpy()
+
+    # Convert back to original dtype
+    if needs_normalization:
+        max_val = float(np.iinfo(original_dtype).max)
+        result = (result * max_val).clip(0, max_val).astype(original_dtype)
+    else:
+        # uint8 or float - just ensure correct dtype
+        result = result.astype(original_dtype)
+        if np.issubdtype(original_dtype, np.floating):
+            result = result.clip(0, 1)
+
+    # Restore original channel order
+    if channel_location == "last":
+        # (N, C, H, W) -> (N, H, W, C)
+        result = np.transpose(result, (0, 2, 3, 1))
+    elif channel_location is None:
+        # (N, 1, H, W) -> (N, H, W)
+        result = result.squeeze(1)
+
+    return result

--- a/src/tests/vision/test_resize.py
+++ b/src/tests/vision/test_resize.py
@@ -1,0 +1,107 @@
+import pytest
+import numpy as np
+
+try:
+    from fenn.vision import resize_batch
+    RESIZE_AVAILABLE = True
+except ImportError:
+    RESIZE_AVAILABLE = False
+
+
+@pytest.mark.skipif(not RESIZE_AVAILABLE, reason="resize_batch not available (torchvision required)")
+class TestResizeBatch:
+    """Test suite for resize_batch function."""
+
+    def test_basic_resize_channels_last(self):
+        """Test basic resize with channels last format."""
+        # Create a simple test image: (1, 100, 100, 3)
+        array = np.random.randint(0, 255, (1, 100, 100, 3), dtype=np.uint8)
+        result = resize_batch(array, size=(50, 50))
+
+        assert result.shape == (1, 50, 50, 3)
+        assert result.dtype == np.uint8
+        assert np.all(result >= 0) and np.all(result <= 255)
+
+    def test_basic_resize_channels_first(self):
+        """Test basic resize with channels first format."""
+        # Create a test image: (1, 3, 100, 100)
+        array = np.random.randint(0, 255, (1, 3, 100, 100), dtype=np.uint8)
+        result = resize_batch(array, size=(50, 50))
+
+        assert result.shape == (1, 3, 50, 50)
+        assert result.dtype == np.uint8
+
+    def test_grayscale_no_channels(self):
+        """Test resize with grayscale (N, H, W)."""
+        array = np.random.randint(0, 255, (1, 100, 100), dtype=np.uint8)
+        result = resize_batch(array, size=(50, 50))
+
+        assert result.shape == (1, 50, 50)
+        assert result.dtype == np.uint8
+
+    def test_float32_preservation(self):
+        """Test that float32 dtype is preserved."""
+        array = np.random.rand(1, 100, 100, 3).astype(np.float32)
+        result = resize_batch(array, size=(50, 50))
+
+        assert result.shape == (1, 50, 50, 3)
+        assert result.dtype == np.float32
+        assert np.all(result >= 0) and np.all(result <= 1)
+
+    def test_different_interpolation_modes(self):
+        """Test different interpolation modes."""
+        array = np.random.randint(0, 255, (1, 100, 100, 3), dtype=np.uint8)
+
+        for mode in ["nearest", "bilinear", "bicubic"]:
+            result = resize_batch(array, size=(50, 50), interpolation=mode)
+            assert result.shape == (1, 50, 50, 3)
+            assert result.dtype == np.uint8
+
+    def test_square_size_int(self):
+        """Test resize with integer size (square output)."""
+        array = np.random.randint(0, 255, (1, 100, 100, 3), dtype=np.uint8)
+        result = resize_batch(array, size=50)
+
+        assert result.shape == (1, 50, 50, 3)
+
+    def test_batch_multiple_images(self):
+        """Test resize with multiple images in batch."""
+        array = np.random.randint(0, 255, (5, 100, 100, 3), dtype=np.uint8)
+        result = resize_batch(array, size=(50, 50))
+
+        assert result.shape == (5, 50, 50, 3)
+        assert result.dtype == np.uint8
+
+    def test_invalid_size(self):
+        """Test that invalid size raises ValueError."""
+        array = np.random.randint(0, 255, (1, 100, 100, 3), dtype=np.uint8)
+
+        with pytest.raises(ValueError):
+            resize_batch(array, size=(-10, 10))
+
+        with pytest.raises(ValueError):
+            resize_batch(array, size=(10, -10))
+
+    def test_invalid_interpolation(self):
+        """Test that invalid interpolation raises ValueError."""
+        array = np.random.randint(0, 255, (1, 100, 100, 3), dtype=np.uint8)
+
+        with pytest.raises(ValueError):
+            resize_batch(array, size=(50, 50), interpolation="invalid_mode")
+
+    def test_invalid_array_type(self):
+        """Test that non-numpy array raises TypeError."""
+        with pytest.raises(TypeError):
+            resize_batch([1, 2, 3], size=(50, 50))
+
+    def test_preserve_channel_order(self):
+        """Test that channel order is preserved."""
+        # Channels first
+        array_cf = np.random.randint(0, 255, (1, 3, 100, 100), dtype=np.uint8)
+        result_cf = resize_batch(array_cf, size=(50, 50))
+        assert result_cf.shape == (1, 3, 50, 50)  # Still channels first
+
+        # Channels last
+        array_cl = np.random.randint(0, 255, (1, 100, 100, 3), dtype=np.uint8)
+        result_cl = resize_batch(array_cl, size=(50, 50))
+        assert result_cl.shape == (1, 50, 50, 3)  # Still channels last


### PR DESCRIPTION
Adding a new function to the vision module to resize a batch of images.

The user is able to provide a desired size (an int for a square or a tuple for a rectangle) and an interpolation method ("nearest", "nearest_exact", "bilinear", "bicubic") which defaults to bilinear. I implemented interpolation using torchvision as this is already an optional dependency in the project. If we do not want this as a dependency let me know and we can use a different library.

NOTE - because we are using an np.ndarray as the input, this will only support an input array with all the same size. If we want to use this to standardize an array of varying sized images we will need to change the implementation.