### PR TITLE
docs: fix typo `FENN` -> `Fenn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ train:
 Use the `@app.entrypoint` decorator. Your configuration variables are automatically passed via `args`.
 
 ```python
-from fenn import FENN
+from fenn import Fenn
 
-app = FENN()
+app = Fenn()
 
 @app.entrypoint
 def main(args):
@@ -101,7 +101,7 @@ if __name__ == "__main__":
 By default, fenn will look for a configuration file named `fenn.yaml` in the current directory. If you would like to use a different name, a different location, or have multiple configuration files for different configurations, you can call `set_config_file()` and update the path or the name of your configuration file. You must assign the filename before calling `run()`.
 
 ```python
-app = FENN()
+app = Fenn()
 app.set_config_file("my_file.yaml")
 ...
 app.run()

--- a/src/fenn/logging/logger.py
+++ b/src/fenn/logging/logger.py
@@ -2,14 +2,14 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from fenn.args import Parser
+from fenn.logging.backends.logging import LoggingBackend
+from fenn.logging.backends.tensorboard import TensorboardBackend
+from fenn.logging.backends.wandb import WandbBackend
 from fenn.secrets.keystore import KeyStore
 
-from fenn.logging.backends.logging import LoggingBackend
-from fenn.logging.backends.wandb import WandbBackend
-from fenn.logging.backends.tensorboard import TensorboardBackend
 
 class Logger:
-    """Singleton logging system for FENN (facade over multiple backends)."""
+    """Singleton logging system for Fenn (facade over multiple backends)."""
 
     _instance: Optional["Logger"] = None
 


### PR DESCRIPTION
The application name `Fenn` was incorrectly written as `FENN` in [README.md](https://github.com/pyfenn/fenn/blob/f41c300355bf9fb2384d62c08023558329985d5a/README.md) and [src/fenn/logging/logger.py](https://github.com/pyfenn/fenn/blob/f41c300355bf9fb2384d62c08023558329985d5a/src/fenn/logging/logger.py). The only change of this PR is to fix the capitalization typo.