### PR TITLE
feat: add remaining fenn.tabular functions

### DIFF
--- a/src/fenn/tabular/__init__.py
+++ b/src/fenn/tabular/__init__.py
@@ -47,3 +47,73 @@ def numeric_profile(
         upper = numeric_df.quantile(1 - clip_quantile)
         numeric_df = numeric_df.clip(lower=lower, upper=upper, axis=1)
     return numeric_df.describe().T
+
+
+def quick_sample(
+    df: pd.DataFrame,
+    n: int = 5,
+    columns: Optional[list] = None,
+    seed: Optional[int] = None
+) -> pd.DataFrame:
+    """
+    Convenience wrapper around head/random sampling,
+    with optional column subset and seed.
+    """
+    subset = df[columns] if columns else df
+    return subset.sample(n=min(n, len(subset)), random_state=seed)
+
+
+def unique_report(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Show number of unique values per column and, for low-cardinality
+    columns, a small frequency table.
+    """
+    result = pd.DataFrame({
+        "unique_count": df.nunique(),
+        "unique_%": (df.nunique() / len(df) * 100).round(2),
+    })
+    return result
+
+
+def corr_overview(
+    df: pd.DataFrame,
+    top_n: int = 10
+) -> pd.DataFrame:
+    """
+    Compute correlations between numeric columns and return
+    the strongest pairs as a tidy table.
+    """
+    numeric_df = df.select_dtypes(include=[np.number])
+    corr_matrix = numeric_df.corr()
+
+    # Convert to tidy format
+    pairs = (
+        corr_matrix.where(
+            np.triu(np.ones(corr_matrix.shape), k=1).astype(bool)
+        )
+        .stack()
+        .reset_index()
+    )
+    pairs.columns = pd.Index(["feature_1", "feature_2", "correlation"])
+    pairs["abs_correlation"] = pairs["correlation"].abs()
+    pairs = pairs.dropna(subset=["correlation"])
+    return pairs.sort_values("abs_correlation", ascending=False).head(top_n)
+
+
+def array_summary(arr: np.ndarray) -> pd.DataFrame:
+    """
+    NumPy-oriented helper for shape, dtype, basic stats,
+    and NaN checks on ndarray.
+    """
+    flat = arr.flatten()
+    return pd.DataFrame([{
+        "shape": arr.shape,
+        "dtype": arr.dtype,
+        "size": arr.size,
+        "mean": float(np.nanmean(flat)),
+        "std": float(np.nanstd(flat)),
+        "min": float(np.nanmin(flat)),
+        "max": float(np.nanmax(flat)),
+        "nan_count": int(np.isnan(flat).sum()),
+        "nan_%": round(float(np.isnan(flat).mean() * 100), 2),
+    }])


### PR DESCRIPTION
Closes #55

Added remaining functions to fenn.tabular module:
- quick_sample() - random sampling with optional column subset and seed
- unique_report() - unique value counts per column
- corr_overview() - strongest correlation pairs as a tidy table
- array_summary() - shape, dtype, stats and NaN checks for NumPy arrays