### PR TITLE
docs: add user guide for Trainer classes and Checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,35 @@ app.set_config_file("my_file.yaml")
 app.run()
 ```
 
+### Training Models
+
+Use built-in trainers to handle your training loops with minimal boilerplate.
+
+```python
+from fenn.nn.trainers import ClassificationTrainer
+from fenn.nn.utils import Checkpoint
+
+@app.entrypoint
+def main(args):
+    # Configure checkpointing
+    checkpoint = Checkpoint(dir="checkpoints/", save_best=True)
+
+    # Initialize trainer
+    trainer = ClassificationTrainer(
+        model=model,
+        loss_fn=nn.CrossEntropyLoss(),
+        optim=optim.Adam(model.parameters()),
+        num_classes=2,
+        checkpoint_config=checkpoint
+    )
+
+    # Fit and Predict
+    trainer.fit(train_loader, epochs=10, val_loader=val_loader)
+    preds = trainer.predict(test_loader)
+```
+
+See [docs/trainers.md](docs/trainers.md) for more details.
+
 ### Run It
 
 ```bash

--- a/src/fenn/nn/trainers/classification_trainer.py
+++ b/src/fenn/nn/trainers/classification_trainer.py
@@ -42,13 +42,14 @@ class ClassificationTrainer(Trainer):
         early_stopping_patience: Optional[int] = None,
         checkpoint_config: Optional[Checkpoint] = None,
     ):
-        """Initialize a Trainer instance to fit a neural network model.
+        """Initialize a ClassificationTrainer instance.
 
         Args:
             model: The neural network model to train.
             loss_fn: The loss function to use.
             optim: The optimizer to use.
             num_classes: The number of classes to predict.
+            multi_label: Whether to use multi-label classification.
             device: The device on which the data will be loaded.
             early_stopping_patience: The number of epochs to wait before early stopping.
             checkpoint_config: The checkpoint configuration. If `None`, checkpointing is disabled.

--- a/src/fenn/nn/trainers/regression_trainer.py
+++ b/src/fenn/nn/trainers/regression_trainer.py
@@ -35,13 +35,13 @@ class RegressionTrainer(Trainer):
         early_stopping_patience: Optional[int] = None,
         checkpoint_config: Optional[Checkpoint] = None,
     ):
-        """Initialize a Trainer instance to fit a neural network model.
+        """Initialize a RegressionTrainer instance.
 
         Args:
             model: The neural network model to train.
             loss_fn: The loss function to use.
             optim: The optimizer to use.
-            num_classes: The number of classes to predict.
+            return_model: Whether to return the 'last' or 'best' model after training.
             device: The device on which the data will be loaded.
             early_stopping_patience: The number of epochs to wait before early stopping.
             checkpoint_config: The checkpoint configuration. If `None`, checkpointing is disabled.


### PR DESCRIPTION
This PR addresses #79 by adding a user guide for Trainer classes and the Checkpoint utility.

Changes:
- Created `docs/trainers.md` with usage examples and explanations.
- Updated `README.md` to include a "Training Models" section with a quick example.
- Improved docstrings for `ClassificationTrainer` and `RegressionTrainer` constructors to be more accurate and include missing arguments.

Closes #79