### PR TITLE
docs: improve docstrings for Trainer, Checkpoint, concrete trainer

### DIFF
--- a/src/fenn/nn/trainers/classification_trainer.py
+++ b/src/fenn/nn/trainers/classification_trainer.py
@@ -26,9 +26,38 @@ from .trainer import Trainer
 
 
 class ClassificationTrainer(Trainer):
-    """
-    ClassificationTrainer is an extension extends the base Trainer to support
-    binary, multi-class, and multi-label classification support.
+    """A trainer for classification tasks with PyTorch models.
+    
+    Supports binary, multi-class, and multi-label classification by adapting
+    the loss computation and prediction logic based on the task type. Handles
+    both single-label (``num_classes == 2`` → binary, ``> 2`` → multiclass) and
+    multi-label (``multi_label=True``) scenarios.
+    
+    The automatic task type detection configures:
+    - Binary: sigmoid activation, BCE loss, threshold at 0.5
+    - Multiclass: softmax activation, cross-entropy loss
+    - Multi-label: sigmoid activation, binary cross-entropy per label
+    
+    Args:
+        model: The neural network model, expected to output logits for
+            the classification task.
+        loss_fn: Loss function compatible with the task type (e.g. BCEWithLogitsLoss
+            for binary/multi-label, CrossEntropyLoss for multiclass).
+        optim: Optimizer for updating trainable parameters.
+        num_classes: Number of classes (or labels in multi-label mode). Must be ``>= 1``.
+        multi_label: Whether this is a multi-label classification problem.
+            Requires ``num_classes >= 2``.
+        device: Device to run training on (``'cpu'``, ``'cuda'``, or ``'mps'``).
+        early_stopping_patience: Stop training after this many epochs without
+            improvement in validation/training loss. ``None`` disables.
+        checkpoint_config: Optional :class:`~fenn.nn.utils.Checkpoint` for
+            saving training state to disk.
+    
+    Note:
+        For binary classification (``num_classes == 2``, ``multi_label=False``),
+        labels should be ``[0, 1]`` shaped tensors. For multiclass, labels should
+        be class indices. For multi-label, labels should be binary vectors of length
+        ``num_classes``.
     """
 
     def __init__(

--- a/src/fenn/nn/trainers/regression_trainer.py
+++ b/src/fenn/nn/trainers/regression_trainer.py
@@ -21,8 +21,24 @@ from .trainer import Trainer
 
 
 class RegressionTrainer(Trainer):
-    """
-    RegressionTrainer is an extension extends the base Trainer to Regression support.
+    """A trainer for regression tasks with PyTorch models.
+    
+    Extends the base :class:`Trainer` with regression-specific metrics (R² score,
+    MSE) and continuous-value prediction logic. Handles single-target regression
+    with optional validation and early stopping.
+    
+    Args:
+        model: The neural network model, expected to output continuous predictions.
+        loss_fn: Loss function suitable for regression (e.g. MSELoss, HuberLoss).
+        optim: Optimizer for updating trainable parameters.
+        return_model: Which model version to return after training. ``'last'``
+            returns the final checkpoint, ``'best'`` returns the best model
+            by validation/training loss.
+        device: Device to run training on (``'cpu'``, ``'cuda'``, or ``'mps'``).
+        early_stopping_patience: Stop training after this many epochs without
+            improvement in loss. ``None`` disables.
+        checkpoint_config: Optional :class:`~fenn.nn.utils.Checkpoint` for
+            saving training state to disk.
     """
 
     def __init__(

--- a/src/fenn/nn/trainers/trainer.py
+++ b/src/fenn/nn/trainers/trainer.py
@@ -18,7 +18,18 @@ from fenn.nn.utils import Checkpoint, ModelPrettyPrinter, TrainingState
 
 
 class Trainer(ABC):
-    """The base Trainer abstract class for classification/Regression tasks."""
+    """The base Trainer abstract class for classification and regression tasks.
+
+    Provides a common training loop with support for early stopping,
+    checkpointing, and validation monitoring. Subclasses must implement
+    :meth:`fit` to define the per-epoch training logic and :meth:`predict`
+    to generate predictions from a model.
+
+    Subclasses:
+        - :class:`ClassificationTrainer` for classification tasks.
+        - :class:`RegressionTrainer` for regression tasks.
+        - :class:`LoRATrainer` for parameter-efficient fine-tuning.
+    """
 
     @abstractmethod
     def __init__(
@@ -75,7 +86,19 @@ class Trainer(ABC):
         summary = ModelPrettyPrinter(self._model).render()
         self._logger.display_info(summary, display_on_terminal=False)
 
-    def _move_to_device(self, batch, device: Union[torch.device, str]) -> Any:
+    def _move_to_device(self, batch: Any, device: Union[torch.device, str]) -> Any:
+        """Recursively move tensor data to the specified device.
+
+        Handles tensors, lists, tuples, and dictionaries of tensors.
+        Non-tensor values are passed through unchanged.
+
+        Args:
+            batch: Input data — a tensor, list, tuple, or dict of tensors.
+            device: Target device (``torch.device`` or string like ``'cuda'``).
+
+        Returns:
+            The input data with all tensors moved to the target device.
+        """
         if torch.is_tensor(batch):
             return batch.to(device)
         if isinstance(batch, (list, tuple)):
@@ -85,14 +108,18 @@ class Trainer(ABC):
         return batch
 
     def _should_save_checkpoint(self, epoch: int, is_last_epoch: bool = False) -> bool:
-        """Check if a checkpoint should be saved at the given epoch.
+        """Check whether a checkpoint should be saved at the given epoch.
+
+        Evaluates the checkpoint configuration to determine if the current
+        epoch qualifies for a checkpoint save based on fixed intervals,
+        explicit epoch lists, or being the final training epoch.
 
         Args:
-            epoch: The current epoch number. (1-indexed)
-            is_last_epoch: Whether this is the last epoch.
+            epoch: The current epoch number (1-indexed).
+            is_last_epoch: Whether this is the final training epoch.
 
         Returns:
-            True if a checkpoint should be saved, False otherwise.
+            ``True`` if a checkpoint should be saved, ``False`` otherwise.
         """
 
         if self._checkpoint is None:
@@ -120,34 +147,44 @@ class Trainer(ABC):
         val_loader: Optional[DataLoader] = None,
         val_epochs: int = 1,
     ):
-        """Train the model with optional validation and early stopping.
+        """Train the model for a fixed number of epochs.
 
-        The behaviour depends on the combination of `val_loader` and
-        ``early_stopping_patience``:
+        Runs the full training loop including forward/backward passes,
+        validation evaluation, checkpointing, and early stopping.
+        The exact behavior depends on the validation and early stopping
+        configuration:
 
         * No validation loader, no early stopping: run full ``epochs``.
         * No validation loader, early stopping set: stop on training loss.
-        * Validation loader provided, no early stopping: evaluate every epoch
-          but continue regardless of metrics.
-        * Validation loader provided and early stopping set: monitor
-          validation loss and stop when it plateaus.
+        * Validation loader provided, no early stopping: evaluate every
+          epoch but continue regardless of metrics.
+        * Validation loader and early stopping set: monitor validation
+          loss and stop when it plateaus for ``early_stopping_patience``
+          epochs.
 
         Args:
-            train_loader: DataLoader for training data.
-            epochs: Total number of epochs to train for.
-            val_loader: DataLoader for validation data (optional).
-            val_epochs: How often to evaluate on validation set (in epochs).
+            train_loader: PyTorch ``DataLoader`` yielding ``(data, labels)``
+                batches for training.
+            epochs: Total number of training epochs. If resuming from a
+                checkpoint, only the remaining epochs are run.
+            val_loader: Optional ``DataLoader`` for validation evaluation.
+            val_epochs: How frequently to evaluate on the validation set
+                (e.g. ``val_epochs=2`` means every 2 epochs).
 
         Returns:
-            The trained model (returned according to ``return_model``).
+            The trained model.
         """
         pass
 
     def _replace_state(self, new_state: TrainingState) -> None:
-        """Replace the current training state with a new state.
+        """Replace the current training state with a previously saved state.
+
+        Loads the model weights and optimizer state from the provided
+        state, effectively restoring training to a checkpointed point.
 
         Args:
-            new_state: The new state to replace the current state with.
+            new_state: A :class:`~fenn.nn.utils.TrainingState` containing
+                the model and optimizer state dicts to restore.
         """
         self._state = new_state
         if new_state.model_state_dict:
@@ -156,10 +193,17 @@ class Trainer(ABC):
             self._optimizer.load_state_dict(new_state.optimizer_state_dict)
 
     def load_checkpoint(self, checkpoint_path: Union[str, Path]) -> None:
-        """Load a checkpoint from a given path to update current training state.
+        """Load a checkpoint from the given file path and restore training state.
+
+        Restores the model weights, optimizer state, and epoch counter from
+        a previously saved checkpoint file.
 
         Args:
-            checkpoint_path: Path to the checkpoint file.
+            checkpoint_path: Path to the ``.pt`` checkpoint file.
+
+        Raises:
+            ValueError: If no checkpoint configuration was provided at init.
+            FileNotFoundError: If the checkpoint file does not exist.
         """
         if self._checkpoint is None:
             raise ValueError("Cannot load checkpoint: checkpoint_config is missing.")
@@ -168,10 +212,17 @@ class Trainer(ABC):
         self._replace_state(new_state)
 
     def load_checkpoint_at_epoch(self, epoch: int) -> None:
-        """Load the checkpoint at the given epoch to update current training state.
+        """Load the checkpoint saved at a specific epoch.
+
+        Searches the checkpoint directory for the saved state at the
+        requested epoch and restores the model and optimizer.
 
         Args:
-            epoch: Epoch to load the checkpoint at.
+            epoch: The epoch whose checkpoint to load (1-indexed).
+
+        Raises:
+            ValueError: If no checkpoint configuration was provided at init.
+            FileNotFoundError: If no checkpoint exists for the given epoch.
         """
         if self._checkpoint is None:
             raise ValueError("Cannot load checkpoint: checkpoint_config is missing.")
@@ -180,7 +231,15 @@ class Trainer(ABC):
         self._replace_state(new_state)
 
     def load_best_checkpoint(self) -> None:
-        """Load the best checkpoint to update current training state."""
+        """Load the best-performing checkpoint into the trainer's model.
+
+        Restores the model weights from the checkpoint with the lowest
+        validation (or training) loss recorded during training.
+
+        Raises:
+            ValueError: If no checkpoint configuration was provided at init.
+            FileNotFoundError: If no best checkpoint file exists.
+        """
         if self._checkpoint is None:
             raise ValueError("Cannot load checkpoint: checkpoint_config is missing.")
 
@@ -189,12 +248,17 @@ class Trainer(ABC):
 
     @abstractmethod
     def predict(self, dataloader_or_batch: Union[DataLoader, torch.Tensor]):
-        """Predicts the output of the model for a given dataloader or batch.
+        """Generate predictions from the trained model.
+
+        Runs inference on the provided data without computing gradients,
+        returning model predictions in the same format as the training
+        labels.
 
         Args:
-            dataloader_or_batch: A DataLoader or a torch tensor.
+            dataloader_or_batch: Either a PyTorch ``DataLoader`` yielding
+                data batches, or a single tensor batch.
 
         Returns:
-            list: A list of predictions.
+            A list of predictions (one per sample).
         """
         pass

--- a/src/fenn/nn/utils/checkpoint.py
+++ b/src/fenn/nn/utils/checkpoint.py
@@ -8,7 +8,25 @@ from fenn.nn.utils.state import TrainingState
 
 
 class Checkpoint:
-    """Checkpoint training state at the given epochs."""
+    """Checkpoint training state at given epochs and/or always the best model.
+
+    Saves full :class:`TrainingState` snapshots (model weights, optimizer
+    state, epoch counter, metrics) during training so that training can be
+    resumed or the best model restored later.
+
+    Args:
+        name: Base filename for checkpoint files (without extension).
+        dir: Directory to save checkpoint files in.
+        epochs: When to save checkpoints — an ``int`` saves every N epochs,
+            a ``list[int]`` saves at specific epochs, or ``None`` to save
+            only the best model.
+        save_best: If ``True``, save the best model seen so far, updated
+            whenever validation/training loss improves.
+
+    Example:
+        >>> checkpoint = Checkpoint(dir="checkpoints/", epochs=5, save_best=True)
+        >>> trainer = Trainer(model, loss_fn, optimizer, checkpoint_config=checkpoint)
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary

Expands documentation for the trainer and checkpoint modules from minimal one-liners to full Google-style docstrings, addressing [#88](https://github.com/pyfenn/fenn/issues/88).

## Changes

**trainer.py:**
- Expanded Trainer class docstring with subclass references (ClassificationTrainer, RegressionTrainer, LoRATrainer)
- Added detailed docstring for `fit()` explaining the validation/early stopping matrix
- Improved `predict()` docstring
- Added docstrings for `_move_to_device()` and `_replace_state()`
- Enhanced `_should_save_checkpoint()`, `load_checkpoint()`, `load_checkpoint_at_epoch()`, `load_best_checkpoint()` with Args and Raises sections

**checkpoint.py:**
- Expanded Checkpoint class docstring with usage example and detailed Args section

**classification_trainer.py:**
- Rewrote class docstring to explain task type detection (binary/multiclass/multilabel) and per-mode behavior

**regression_trainer.py:**
- Added class docstring explaining regression-specific metrics (R², MSE) and return_model parameter

## Testing
No behavioral changes — these are documentation improvements only. 4 files changed, 161 insertions(-), 34 deletions(-).