### PR TITLE
docs(readme): expand 'Initialize a Project' to cover pull behavior (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,52 @@ uv pip install fenn
 
 ### Initialize a Project
 
-Run the CLI tool to see which repositories are available and to download a template together with its configuration file. First, list the available repositories:
+Use the CLI to discover and download a project template.
+
+#### 1. List available templates
 
 ```bash
 fenn list
-````
-
-Then, download one of the available templates (here `empty` is just an example):
-
-```bash
-fenn pull empty
 ```
 
-This command downloads the selected template into the current directory and generates the corresponding configuration file, which can be customized before running or extending the project.
+This fetches the directory listing from [`pyfenn/templates`](https://github.com/pyfenn/templates) and prints the templates you can use.
+
+#### 2. Pull a template
+
+```bash
+fenn pull <template> [path]
+```
+
+Examples:
+
+```bash
+fenn pull empty            # pull into the current directory
+fenn pull empty ./my-proj  # pull into ./my-proj (created if missing)
+```
+
+Each template ships at least a `main.py` entrypoint and a `fenn.yaml` configuration file in the target directory. Most templates also include a `README.md`, a `requirements.txt`, and a `modules/` directory with example model and dataset code.
+
+To avoid clobbering work, `fenn pull` refuses to write into a non-empty target directory. Pass `--force` to overwrite existing files:
+
+```bash
+fenn pull empty --force
+```
+
+Hidden entries (those starting with `.`, such as `.git`) do not count as "non-empty".
+
+#### 3. Customize and run
+
+Open the generated `fenn.yaml` and adjust hyperparameters, paths, logging, and integrations for your project (see [Configuration](#configuration) below). Then run the entrypoint:
+
+```bash
+python main.py
+```
+
+#### Common issues
+
+- **`Template <name> not found`** — The template name doesn't match a directory in [`pyfenn/templates`](https://github.com/pyfenn/templates). Run `fenn list` to see valid names.
+- **`Refusing to pull into non-empty directory`** — Either pull into an empty directory, point `path` at a fresh one, or pass `--force` to overwrite.
+- **`Network error` / `Failed to check template existence`** — Check connectivity. The CLI uses the unauthenticated GitHub API to look up and download templates, which is subject to GitHub's rate limit.
 
 ### Configuration
 


### PR DESCRIPTION
Closes #95.

## Summary
- Rewrites the **Initialize a Project** section as a 3-step walkthrough: `fenn list` → `fenn pull` → customize + run.
- Documents the optional `path` positional argument and shows a concrete example.
- Lists the files a fresh template produces (`main.py` + `fenn.yaml` always; most templates also add `README.md`, `requirements.txt`, and `modules/`).
- Documents the **non-empty-directory guard** and the `--force` override, including the detail that dotfiles don't count toward "non-empty".
- Adds a small **Common issues** list covering `Template <name> not found`, `Refusing to pull into non-empty directory`, and `Network error` / GitHub API rate-limit cases.
- Drops a stray 4-backtick fence on the existing `fenn list` block (single-char typo).

## Why
Issue #95 reports that first-time users have to guess what `fenn pull` does to their working directory and which files appear. The current README says only "downloads the selected template into the current directory and generates the corresponding configuration file", which doesn't cover: (1) that pulling into a non-empty directory is rejected, (2) what `--force` does, (3) what files are produced, or (4) what to do when GitHub returns 403 / 404.

## Verification
README-only change. Every behavior described was read out of the current source on `main`:

- Non-empty-directory guard and `--force` override: `src/fenn/cli/pull.py`, `execute()`.
- Dotfiles excluded from the "non-empty" check: `has_visible_files = any(not item.name.startswith(".") for item in target_dir.iterdir())` in the same function.
- Optional `path` positional argument with default `.`: `src/fenn/cli/__init__.py`, `p_pull.add_argument("path", nargs="?", default=".", ...)`.
- Template archive layout (`templates-main/<template>/`) and per-template files: `src/fenn/cli/pull.py`, `_download_template()`; cross-checked against `pyfenn/templates` (every template directory contains at least `main.py` and `fenn.yaml`; most also have `README.md`, `requirements.txt`, and `modules/`).
- Error messages (`Template ... not found`, `Refusing to pull into non-empty directory`, `Failed to check template existence`, `Network error: ...`): grepped verbatim from `src/fenn/cli/pull.py`.
- Rendered locally; the `[Configuration](#configuration)` link resolves to the existing `### Configuration` heading immediately below.

## Scope / safety
- Docs-only diff in `README.md`. No code, tests, workflows, or dependencies touched.
- No behavior change, no security surface.

