### PR TITLE
docs(readme): expand common issues and add CLI reference table (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ python main.py
 - **`Template <name> not found`** — The template name doesn't match a directory in [`pyfenn/templates`](https://github.com/pyfenn/templates). Run `fenn list` to see valid names.
 - **`Refusing to pull into non-empty directory`** — Either pull into an empty directory, point `path` at a fresh one, or pass `--force` to overwrite.
 - **`Network error` / `Failed to check template existence`** — Check connectivity. The CLI uses the unauthenticated GitHub API to look up and download templates, which is subject to GitHub's rate limit.
+- **`fenn: command not found` after installation** — Your Python scripts directory may not be on your `PATH`. Try running with `python -m fenn` instead, or add the scripts directory to your PATH. On most systems: `export PATH="$HOME/.local/bin:$PATH"`.
+- **`fenn.yaml not found` when running `main.py`** — Make sure you are running the script from the same directory that contains `fenn.yaml`. fenn looks for the config file in the current working directory by default.
+- **`KeyError` on `args['section']['key']`** — The key referenced in your code does not exist in `fenn.yaml`. Double-check spelling in both files. YAML is case-sensitive.
+- **`ModuleNotFoundError` after pulling a template** — Install the template's dependencies first: `pip install -r requirements.txt`.
+- **GitHub API rate limit exceeded during `fenn list` or `fenn pull`** — The unauthenticated GitHub API allows 60 requests/hour per IP. Wait a few minutes and try again, or set a `GITHUB_TOKEN` environment variable if your fenn version supports authenticated requests.
 
 ### Configuration
 
@@ -211,6 +216,17 @@ def main(args):
     trainer.fit(train_loader, epochs=10, val_loader=val_loader)
     preds = trainer.predict(test_loader)
 ```
+
+## CLI Reference
+
+A quick reference for all available fenn CLI commands.
+
+| Command | Description |
+|---|---|
+| `fenn list` | List all available templates from [`pyfenn/templates`](https://github.com/pyfenn/templates) |
+| `fenn pull <template>` | Pull a template into the current directory |
+| `fenn pull <template> <path>` | Pull a template into the specified path (created if missing) |
+| `fenn pull <template> --force` | Pull a template and overwrite existing files |
 
 ## Cite fenn
 


### PR DESCRIPTION
## Summary

This PR follows up on issue #95 and the improvements introduced in #96 by expanding the **Common Issues** section with additional real-world error cases, and adding a **CLI Reference** table for quick command lookup.

## Changes

### Expanded `Common Issues` section

Added 5 new error entries that new users commonly encounter but were not previously documented:

- **`fenn: command not found`** — explains PATH issue and `python -m fenn` workaround
- **`fenn.yaml not found` at runtime** — clarifies that the config must be in the current working directory
- **`KeyError` on `args[section][key]`** — guides users to check YAML key spelling and case sensitivity
- **`ModuleNotFoundError` after template pull** — reminds users to run `pip install -r requirements.txt`
- **GitHub API rate limit** — explains the 60 req/hour limit and suggests `GITHUB_TOKEN` as a workaround

### Added `CLI Reference` table

A compact reference table listing all available `fenn` CLI commands and their descriptions, making it easy for users to find the right command without reading the full prose.

## Motivation

As noted in #95, first-time users hit friction during setup when error messages appear with no guidance in the docs. These additions directly address the "common edge cases" acceptance criterion from that issue.

## Testing

Documentation-only change — no code modified.

Closes #95
