### PR TITLE
issue98 - detect crashed "running" sessions via mtime #1

### DIFF
--- a/src/fenn/cli/pull.py
+++ b/src/fenn/cli/pull.py
@@ -51,11 +51,11 @@ def execute(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    has_visible_files = any(
+    has_visible_files = target_dir.exists() and any(
         not item.name.startswith(".") for item in target_dir.iterdir()
     )
 
-    if target_dir.exists() and has_visible_files and not force:
+    if has_visible_files and not force:
         if HAS_RICH:
             Console().print(
                 f"[red]Refusing to pull into non-empty directory [yellow]{target_dir}[/yellow].\nUse [yellow]--force[/yellow] to override existing files.[/red]"

--- a/src/fenn/dashboard/app.py
+++ b/src/fenn/dashboard/app.py
@@ -3,8 +3,9 @@
 import argparse
 import logging
 from pathlib import Path
+from typing import Optional
 
-from flask import Flask, abort, jsonify, render_template
+from flask import Flask, abort, jsonify, render_template, request
 
 try:
     from fenn.dashboard.scanner import FennScanner
@@ -77,6 +78,80 @@ def api_session(project_name: str, session_id: str):
         abort(404)
     data.pop("projects", None)
     return jsonify(data)
+
+
+# Pagination / filtering limits. 200 is large enough for any plausible UI
+# without letting a client ask for "everything" by accident.
+_MAX_LIMIT = 200
+_DEFAULT_LIMIT = 20
+
+
+def _api_error(code: str, message: str, param: Optional[str] = None):
+    """Standard 400 envelope so clients can branch on `error.code`."""
+    body = {"error": {"code": code, "message": message}}
+    if param is not None:
+        body["error"]["param"] = param
+    return jsonify(body), 400
+
+
+def _parse_int_arg(
+    name: str, raw: Optional[str], default: int, min_v: int, max_v: int
+) -> int:
+    if raw is None or raw == "":
+        return default
+    try:
+        v = int(raw)
+    except ValueError:
+        raise _ApiBadRequest(f"{name} must be an integer", name)
+    if v < min_v or v > max_v:
+        raise _ApiBadRequest(
+            f"{name} must be between {min_v} and {max_v}", name
+        )
+    return v
+
+
+class _ApiBadRequest(Exception):
+    def __init__(self, message: str, param: Optional[str] = None):
+        self.message = message
+        self.param = param
+
+
+@app.route("/api/sessions")
+def api_sessions():
+    """Filtered, sorted, paginated session listing.
+
+    Query params: project, status, limit (1..200, default 20), offset (>=0,
+    default 0), sort (field, optionally ``-`` prefixed for descending).
+    """
+    try:
+        project = request.args.get("project") or None
+        status = request.args.get("status") or None
+        sort = request.args.get("sort") or "-started"
+        limit = _parse_int_arg(
+            "limit", request.args.get("limit"), _DEFAULT_LIMIT, 1, _MAX_LIMIT
+        )
+        offset = _parse_int_arg(
+            "offset", request.args.get("offset"), 0, 0, 1_000_000
+        )
+
+        try:
+            result = scanner.list_sessions(
+                project=project,
+                status=status,
+                limit=limit,
+                offset=offset,
+                sort=sort,
+            )
+        except ValueError as e:
+            # Pick the parameter name from the message so the envelope is
+            # consistent with the int-parsing errors above.
+            msg = str(e)
+            param = "status" if msg.startswith("status") else "sort"
+            return _api_error("invalid_param", msg, param)
+
+        return jsonify(result)
+    except _ApiBadRequest as e:
+        return _api_error("invalid_param", e.message, e.param)
 
 
 @app.errorhandler(404)

--- a/src/fenn/dashboard/scanner.py
+++ b/src/fenn/dashboard/scanner.py
@@ -1,6 +1,7 @@
 """FnXML file discovery and parsing for the Fenn dashboard."""
 
 import os
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from xml.etree import ElementTree as ET
@@ -11,6 +12,22 @@ _DEFAULT_DIRS = [
     "~/logger",
     "~/.fenn/logs",
 ]
+
+# A session whose .fn file is missing the closing tag and has not been touched
+# for this many seconds is treated as crashed rather than still running.
+_DEFAULT_RUNNING_TIMEOUT_S = 300
+
+
+def _running_timeout_s() -> float:
+    """Read the running-session timeout from FENN_RUNNING_TIMEOUT_S, with fallback."""
+    raw = os.environ.get("FENN_RUNNING_TIMEOUT_S")
+    if not raw:
+        return float(_DEFAULT_RUNNING_TIMEOUT_S)
+    try:
+        v = float(raw)
+        return v if v > 0 else float(_DEFAULT_RUNNING_TIMEOUT_S)
+    except ValueError:
+        return float(_DEFAULT_RUNNING_TIMEOUT_S)
 
 
 class FennScanner:
@@ -128,6 +145,13 @@ class FennScanner:
             file_size = 0
             file_mtime = 0.0
 
+        # A "running" session whose file has been idle past the timeout is
+        # almost certainly a crashed process — surface that distinctly so the
+        # running counter does not drift over time.
+        if status == "running" and file_mtime > 0:
+            if time.time() - file_mtime > _running_timeout_s():
+                status = "crashed"
+
         return {
             "session_id": root.get("session_id", path.stem),
             "project": root.get("project", path.parent.name),
@@ -167,6 +191,7 @@ class FennScanner:
                     "name": name,
                     "session_count": 0,
                     "running_count": 0,
+                    "crashed_count": 0,
                     "warning_count": 0,
                     "exception_count": 0,
                     "last_active": s["started"],
@@ -177,6 +202,8 @@ class FennScanner:
             p["exception_count"] += s["exception_count"]
             if s["status"] == "running":
                 p["running_count"] += 1
+            elif s["status"] == "crashed":
+                p["crashed_count"] += 1
 
         project_list = sorted(
             projects.values(), key=lambda p: p["last_active"], reverse=True
@@ -185,6 +212,7 @@ class FennScanner:
         total_warnings = sum(s["warning_count"] for s in sessions)
         total_exceptions = sum(s["exception_count"] for s in sessions)
         running = sum(1 for s in sessions if s["status"] == "running")
+        crashed = sum(1 for s in sessions if s["status"] == "crashed")
 
         return {
             "projects": project_list,
@@ -194,6 +222,7 @@ class FennScanner:
             "total_warnings": total_warnings,
             "total_exceptions": total_exceptions,
             "running_sessions": running,
+            "crashed_sessions": crashed,
             "active_page": "home",
         }
 
@@ -210,6 +239,7 @@ class FennScanner:
             "sessions": sessions,
             "total_sessions": len(sessions),
             "running_sessions": sum(1 for s in sessions if s["status"] == "running"),
+            "crashed_sessions": sum(1 for s in sessions if s["status"] == "crashed"),
             "total_warnings": sum(s["warning_count"] for s in sessions),
             "total_exceptions": sum(s["exception_count"] for s in sessions),
             "active_page": "project",

--- a/src/fenn/dashboard/scanner.py
+++ b/src/fenn/dashboard/scanner.py
@@ -3,7 +3,7 @@
 import os
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from xml.etree import ElementTree as ET
 
 # Default directories to scan (resolved at runtime)
@@ -16,6 +16,19 @@ _DEFAULT_DIRS = [
 # A session whose .fn file is missing the closing tag and has not been touched
 # for this many seconds is treated as crashed rather than still running.
 _DEFAULT_RUNNING_TIMEOUT_S = 300
+
+# Short TTL for the directory listing — absorbs request bursts (e.g. session
+# pages auto-refreshing) without making the dashboard feel stale.
+_FILES_CACHE_TTL_S = 1.0
+
+_VALID_STATUSES = ("running", "crashed", "completed", "failed")
+_VALID_SORT_FIELDS = (
+    "started",
+    "ended",
+    "duration_s",
+    "warning_count",
+    "exception_count",
+)
 
 
 def _running_timeout_s() -> float:
@@ -35,6 +48,15 @@ class FennScanner:
 
     def __init__(self, extra_dirs: Optional[List[str]] = None) -> None:
         self._dirs: List[Path] = []
+
+        # Parse-result cache keyed by file path. Stores (mtime, parsed_dict).
+        # Entries are reused only when mtime matches, so any file write
+        # (including in-progress logging) invalidates naturally.
+        self._parse_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+
+        # Directory-listing cache: (timestamp, files). Reused for up to
+        # _FILES_CACHE_TTL_S to absorb bursty requests cheaply.
+        self._files_cache: Optional[Tuple[float, List[Path]]] = None
 
         # Load from environment variable
         env_dirs = os.environ.get("FENN_LOG_DIRS", "")
@@ -59,6 +81,8 @@ class FennScanner:
         p = Path(path).expanduser().resolve()
         if p not in self._dirs:
             self._dirs.append(p)
+        # Invalidate the listing cache so the new directory is picked up.
+        self._files_cache = None
 
     # ------------------------------------------------------------------
     # Public API
@@ -66,6 +90,12 @@ class FennScanner:
 
     def find_fn_files(self) -> List[Path]:
         """Return all .fn files sorted by modification time (newest first)."""
+        now = time.time()
+        if self._files_cache is not None:
+            ts, cached = self._files_cache
+            if now - ts < _FILES_CACHE_TTL_S:
+                return cached
+
         files: List[Path] = []
         for d in self._dirs:
             if d.exists() and d.is_dir():
@@ -76,10 +106,40 @@ class FennScanner:
             if f not in seen:
                 seen.add(f)
                 unique.append(f)
-        return sorted(unique, key=lambda f: f.stat().st_mtime, reverse=True)
+        ordered = sorted(unique, key=lambda f: f.stat().st_mtime, reverse=True)
+        self._files_cache = (now, ordered)
+        return ordered
 
     def parse_fn_file(self, path: Path) -> Optional[Dict[str, Any]]:
-        """Parse a single .fn file. Handles incomplete (running) sessions."""
+        """Parse a single .fn file. Handles incomplete (running) sessions.
+
+        Results are cached by ``(path, mtime)``; identical files are not
+        re-parsed across requests. Running sessions are re-evaluated against
+        the configured timeout on every call, since their "crashed" flip
+        depends on wall-clock time rather than file content.
+        """
+        key = str(path)
+        try:
+            stat = path.stat()
+        except OSError:
+            self._parse_cache.pop(key, None)
+            return None
+        mtime = stat.st_mtime
+
+        cached = self._parse_cache.get(key)
+        if cached is not None and cached[0] == mtime:
+            return self._refresh_running_status(cached[1], mtime)
+
+        parsed = self._parse_uncached(path, stat)
+        if parsed is None:
+            self._parse_cache.pop(key, None)
+            return None
+        self._parse_cache[key] = (mtime, parsed)
+        return self._refresh_running_status(parsed, mtime)
+
+    def _parse_uncached(
+        self, path: Path, stat: os.stat_result
+    ) -> Optional[Dict[str, Any]]:
         try:
             content = path.read_text(encoding="utf-8")
         except (OSError, PermissionError):
@@ -138,20 +198,6 @@ class FennScanner:
         warnings = sum(1 for e in entries if e["level"] == "warning")
         exceptions = sum(1 for e in entries if e["level"] == "exception")
 
-        try:
-            file_size = path.stat().st_size
-            file_mtime = path.stat().st_mtime
-        except OSError:
-            file_size = 0
-            file_mtime = 0.0
-
-        # A "running" session whose file has been idle past the timeout is
-        # almost certainly a crashed process — surface that distinctly so the
-        # running counter does not drift over time.
-        if status == "running" and file_mtime > 0:
-            if time.time() - file_mtime > _running_timeout_s():
-                status = "crashed"
-
         return {
             "session_id": root.get("session_id", path.stem),
             "project": root.get("project", path.parent.name),
@@ -165,9 +211,24 @@ class FennScanner:
             "warning_count": warnings,
             "exception_count": exceptions,
             "file_path": str(path),
-            "file_size": file_size,
-            "file_mtime": file_mtime,
+            "file_size": stat.st_size,
+            "file_mtime": stat.st_mtime,
         }
+
+    @staticmethod
+    def _refresh_running_status(
+        parsed: Dict[str, Any], mtime: float
+    ) -> Dict[str, Any]:
+        """Re-evaluate stale "running" sessions against the current timeout.
+
+        Cached results are reused across requests, but the running→crashed
+        flip is time-dependent. Caller-side staleness is cheap to check and
+        keeps the cache safe to share across calls.
+        """
+        if parsed.get("status") == "running" and mtime > 0:
+            if time.time() - mtime > _running_timeout_s():
+                return {**parsed, "status": "crashed"}
+        return parsed
 
     def get_all_sessions(self) -> List[Dict[str, Any]]:
         """Return all parsed sessions, newest first."""
@@ -249,8 +310,15 @@ class FennScanner:
     def get_session(
         self, project_name: str, session_id: str
     ) -> Optional[Dict[str, Any]]:
-        """Return full data for a single session."""
-        for path in self.find_fn_files():
+        """Return full data for a single session.
+
+        Fenn writes ``<session_id>.fn`` so the filename stem matches the id;
+        we prefer those candidates and fall back to a full scan only if the
+        convention does not hold (e.g. user-supplied legacy files).
+        """
+        all_files = self.find_fn_files()
+        candidates = [p for p in all_files if p.stem == session_id] or all_files
+        for path in candidates:
             parsed = self.parse_fn_file(path)
             if (
                 parsed
@@ -265,6 +333,65 @@ class FennScanner:
                     "active_project": project_name,
                 }
         return None
+
+    # ------------------------------------------------------------------
+    # Filtered / paginated listing
+    # ------------------------------------------------------------------
+
+    def list_sessions(
+        self,
+        project: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 20,
+        offset: int = 0,
+        sort: str = "-started",
+    ) -> Dict[str, Any]:
+        """Return a filtered, sorted, paginated slice of sessions.
+
+        ``sort`` is a field name optionally prefixed with ``-`` for descending
+        order. Valid fields: started, ended, duration_s, warning_count,
+        exception_count. Status must be one of running/crashed/completed/failed.
+
+        Raises ``ValueError`` on invalid status or sort field; callers are
+        responsible for converting these into HTTP-shaped errors.
+        """
+        if status is not None and status not in _VALID_STATUSES:
+            raise ValueError(
+                f"status must be one of {list(_VALID_STATUSES)}"
+            )
+
+        descending = sort.startswith("-")
+        field = sort[1:] if descending else sort
+        if field not in _VALID_SORT_FIELDS:
+            raise ValueError(
+                f"sort field must be one of {list(_VALID_SORT_FIELDS)}"
+            )
+
+        sessions = self.get_all_sessions()
+        if project:
+            sessions = [s for s in sessions if s["project"] == project]
+        if status:
+            sessions = [s for s in sessions if s["status"] == status]
+
+        # Sentinel keeps None values consistently last (asc) / first (desc)
+        # without crashing the comparison on mixed types.
+        def sort_key(s: Dict[str, Any]):
+            v = s.get(field)
+            return (v is None, v if v is not None else "")
+
+        sessions.sort(key=sort_key, reverse=descending)
+
+        total = len(sessions)
+        items = sessions[offset : offset + limit]
+        # Strip the heavy 'entries' list from the listing payload — clients
+        # that need per-entry data fetch the single-session endpoint.
+        slim = [{k: v for k, v in s.items() if k != "entries"} for s in items]
+        return {
+            "items": slim,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
 
     def format_duration(self, seconds: Optional[int]) -> str:
         if seconds is None:

--- a/src/fenn/dashboard/static/style.css
+++ b/src/fenn/dashboard/static/style.css
@@ -496,6 +496,9 @@ tr:hover td { background: var(--surface-2); }
 .badge-running  { background: var(--success-bg);  color: var(--success); }
 .badge-completed{ background: var(--info-bg);      color: var(--info); }
 .badge-failed   { background: var(--error-bg);     color: var(--error); }
+.badge-crashed  { background: var(--warning-bg);   color: var(--warning); }
+
+.has-crashed    { color: var(--warning); }
 
 .badge-info     { background: var(--info-bg);      color: var(--info); }
 .badge-warning  { background: var(--warning-bg);   color: var(--warning); }

--- a/src/fenn/dashboard/templates/index.html
+++ b/src/fenn/dashboard/templates/index.html
@@ -31,6 +31,10 @@
     <div class="stat-label">Exceptions</div>
     <div class="stat-value">{{ total_exceptions }}</div>
   </div>
+  <div class="stat-card warning">
+    <div class="stat-label">Crashed</div>
+    <div class="stat-value">{{ crashed_sessions }}</div>
+  </div>
 </div>
 
 {% if projects %}
@@ -58,6 +62,9 @@
       {% endif %}
       {% if p.exception_count > 0 %}
       <span class="project-stat has-error">✕ {{ p.exception_count }}</span>
+      {% endif %}
+      {% if p.crashed_count > 0 %}
+      <span class="project-stat has-crashed">⊘ {{ p.crashed_count }}</span>
       {% endif %}
     </div>
 
@@ -103,8 +110,12 @@
           <td class="td-mono">{{ s.started }}</td>
           <td class="td-mono">{{ s.duration_s | duration }}</td>
           <td>
-            {% if s.status == 'failed' %}
+            {% if s.status == 'crashed' %}
+            <span class="badge badge-crashed">crashed</span>
+            {% elif s.status == 'failed' %}
             <span class="badge badge-failed">failed</span>
+            {% elif s.status == 'running' %}
+            <span class="badge badge-running"><span class="pulse-dot"></span>running</span>
             {% else %}
             <span class="badge badge-completed">completed</span>
             {% endif %}

--- a/src/fenn/dashboard/templates/project.html
+++ b/src/fenn/dashboard/templates/project.html
@@ -26,6 +26,10 @@
     <div class="stat-value">{{ running_sessions }}</div>
   </div>
   <div class="stat-card warning">
+    <div class="stat-label">Crashed</div>
+    <div class="stat-value">{{ crashed_sessions }}</div>
+  </div>
+  <div class="stat-card warning">
     <div class="stat-label">Warnings</div>
     <div class="stat-value">{{ total_warnings }}</div>
   </div>
@@ -70,6 +74,8 @@
             <span class="badge badge-running">
               <span class="pulse-dot"></span>running
             </span>
+            {% elif s.status == 'crashed' %}
+            <span class="badge badge-crashed">crashed</span>
             {% elif s.status == 'failed' %}
             <span class="badge badge-failed">failed</span>
             {% else %}

--- a/src/fenn/dashboard/templates/session.html
+++ b/src/fenn/dashboard/templates/session.html
@@ -23,7 +23,13 @@
 <div class="page-header">
   <h1 class="page-title" style="font-family:var(--font-mono); font-size:18px; letter-spacing:0;">
     {{ session_id }}
-    {% if status == 'failed' %}
+    {% if status == 'crashed' %}
+    <span class="badge badge-crashed" style="font-size:12px; margin-left:8px; vertical-align:middle;">crashed</span>
+    {% elif status == 'running' %}
+    <span class="badge badge-running" style="font-size:12px; margin-left:8px; vertical-align:middle;">
+      <span class="pulse-dot"></span>running
+    </span>
+    {% elif status == 'failed' %}
     <span class="badge badge-failed" style="font-size:12px; margin-left:8px; vertical-align:middle;">failed</span>
     {% else %}
     <span class="badge badge-completed" style="font-size:12px; margin-left:8px; vertical-align:middle;">completed</span>

--- a/src/tests/dashboard/test_api.py
+++ b/src/tests/dashboard/test_api.py
@@ -1,0 +1,252 @@
+"""Unit tests for the /api/sessions endpoint (Pick 3)."""
+
+import pytest
+
+from fenn.dashboard.app import app
+from fenn.dashboard.scanner import FennScanner
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FN_TMPL = """\
+<?xml version="1.0" encoding="utf-8"?>
+<fenn-log project="{project}" session_id="{sid}" started="{started}">
+  <meta ended="{ended}" duration_s="{dur}" status="{status}" />
+</fenn-log>
+"""
+
+_RUNNING_TMPL = """\
+<?xml version="1.0" encoding="utf-8"?>
+<fenn-log project="{project}" session_id="{sid}" started="{started}">
+  <entry ts="{started}" kind="print" level="info">running</entry>
+"""
+
+
+def _write(path, content):
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def scanner_with_sessions(tmp_path):
+    """Return a FennScanner loaded with a small set of known sessions."""
+    sessions = [
+        dict(project="alpha", sid="a1", started="2026-05-21 07:00:00",
+             ended="2026-05-21 07:00:10", dur=10, status="completed"),
+        dict(project="alpha", sid="a2", started="2026-05-21 08:00:00",
+             ended="2026-05-21 08:00:05", dur=5, status="failed"),
+        dict(project="beta",  sid="b1", started="2026-05-21 06:00:00",
+             ended="2026-05-21 06:00:20", dur=20, status="completed"),
+    ]
+    for s in sessions:
+        _write(tmp_path / f"{s['sid']}.fn", _FN_TMPL.format(**s))
+
+    scanner = FennScanner(extra_dirs=[str(tmp_path)])
+    return scanner
+
+
+@pytest.fixture()
+def client(scanner_with_sessions):
+    """Flask test client wired to a fresh scanner with known data."""
+    import fenn.dashboard.app as app_module
+    original = app_module.scanner
+    app_module.scanner = scanner_with_sessions
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+    app_module.scanner = original
+
+
+# ---------------------------------------------------------------------------
+# Response shape
+# ---------------------------------------------------------------------------
+
+
+class TestApiSessionsShape:
+    """The /api/sessions response must always include the standard envelope."""
+
+    def test_default_response_shape(self, client):
+        """Default call must return items, total, limit, and offset keys."""
+        resp = client.get("/api/sessions")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "items" in data
+        assert "total" in data
+        assert "limit" in data
+        assert "offset" in data
+
+    def test_items_omit_entries(self, client):
+        """Session items in listing must not include the 'entries' key."""
+        resp = client.get("/api/sessions")
+        data = resp.get_json()
+        for item in data["items"]:
+            assert "entries" not in item
+
+    def test_default_limit_is_20(self, client):
+        """Default limit must equal 20."""
+        resp = client.get("/api/sessions")
+        data = resp.get_json()
+        assert data["limit"] == 20
+
+    def test_default_offset_is_0(self, client):
+        """Default offset must equal 0."""
+        resp = client.get("/api/sessions")
+        data = resp.get_json()
+        assert data["offset"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+
+class TestApiSessionsFilter:
+    """project= and status= query parameters must filter results."""
+
+    def test_filter_by_project(self, client):
+        """?project=alpha should return only alpha sessions."""
+        resp = client.get("/api/sessions?project=alpha")
+        data = resp.get_json()
+        assert all(s["project"] == "alpha" for s in data["items"])
+        assert data["total"] == 2
+
+    def test_filter_by_status_completed(self, client):
+        """?status=completed should return only completed sessions."""
+        resp = client.get("/api/sessions?status=completed")
+        data = resp.get_json()
+        assert all(s["status"] == "completed" for s in data["items"])
+
+    def test_filter_by_project_and_status(self, client):
+        """Combined project + status filter must AND the two predicates."""
+        resp = client.get("/api/sessions?project=alpha&status=failed")
+        data = resp.get_json()
+        assert data["total"] == 1
+        assert data["items"][0]["session_id"] == "a2"
+
+    def test_unknown_project_returns_empty(self, client):
+        """Filter for a non-existent project must return empty items list."""
+        resp = client.get("/api/sessions?project=nope")
+        data = resp.get_json()
+        assert data["total"] == 0
+        assert data["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+
+class TestApiSessionsPagination:
+    """limit= and offset= must slice results correctly."""
+
+    def test_limit_respected(self, client):
+        """?limit=1 should return exactly one item."""
+        resp = client.get("/api/sessions?limit=1")
+        data = resp.get_json()
+        assert len(data["items"]) == 1
+        assert data["limit"] == 1
+
+    def test_offset_skips_items(self, client):
+        """?offset=2 should skip the first two results."""
+        all_resp = client.get("/api/sessions").get_json()
+        paged_resp = client.get("/api/sessions?offset=2").get_json()
+        if all_resp["total"] >= 3:
+            assert paged_resp["items"][0]["session_id"] == all_resp["items"][2]["session_id"]
+
+    def test_offset_beyond_total_returns_empty(self, client):
+        """offset larger than total must return zero items."""
+        resp = client.get("/api/sessions?offset=1000")
+        data = resp.get_json()
+        assert data["items"] == []
+        assert data["total"] == 3  # total is unaffected by offset
+
+
+# ---------------------------------------------------------------------------
+# Sorting
+# ---------------------------------------------------------------------------
+
+
+class TestApiSessionsSort:
+    """sort= parameter must reorder results."""
+
+    def test_sort_by_started_descending(self, client):
+        """Default sort (-started) should put the newest session first."""
+        resp = client.get("/api/sessions?sort=-started")
+        data = resp.get_json()
+        starts = [s["started"] for s in data["items"]]
+        assert starts == sorted(starts, reverse=True)
+
+    def test_sort_by_duration_ascending(self, client):
+        """?sort=duration_s should order shortest first."""
+        resp = client.get("/api/sessions?sort=duration_s")
+        data = resp.get_json()
+        durations = [s["duration_s"] for s in data["items"] if s["duration_s"] is not None]
+        assert durations == sorted(durations)
+
+    def test_sort_by_started_ascending(self, client):
+        """?sort=started should order oldest first."""
+        resp = client.get("/api/sessions?sort=started")
+        data = resp.get_json()
+        starts = [s["started"] for s in data["items"]]
+        assert starts == sorted(starts)
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestApiSessionsErrors:
+    """Invalid inputs must return 400 with a structured error envelope."""
+
+    def _assert_error(self, resp, expected_code, expected_param=None):
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert "error" in body
+        assert body["error"]["code"] == expected_code
+        if expected_param is not None:
+            assert body["error"]["param"] == expected_param
+
+    def test_invalid_status_value(self, client):
+        """Unknown status string must return 400 with param='status'."""
+        resp = client.get("/api/sessions?status=unknown")
+        self._assert_error(resp, "invalid_param", "status")
+
+    def test_invalid_sort_field(self, client):
+        """Unknown sort field must return 400 with param='sort'."""
+        resp = client.get("/api/sessions?sort=nosuchfield")
+        self._assert_error(resp, "invalid_param", "sort")
+
+    def test_non_integer_limit(self, client):
+        """Non-numeric limit must return 400 with param='limit'."""
+        resp = client.get("/api/sessions?limit=abc")
+        self._assert_error(resp, "invalid_param", "limit")
+
+    def test_limit_out_of_range(self, client):
+        """limit=0 is below the minimum (1) and must be rejected."""
+        resp = client.get("/api/sessions?limit=0")
+        self._assert_error(resp, "invalid_param", "limit")
+
+    def test_negative_offset(self, client):
+        """Negative offset must return 400."""
+        resp = client.get("/api/sessions?offset=-1")
+        self._assert_error(resp, "invalid_param", "offset")
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: existing endpoints still work
+# ---------------------------------------------------------------------------
+
+
+class TestExistingEndpoints:
+    """Existing API routes must not be broken by Pick 3 additions."""
+
+    def test_api_overview_still_returns_200(self, client):
+        """/api/overview should remain functional."""
+        resp = client.get("/api/overview")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "projects" in data
+        assert "total_sessions" in data

--- a/src/tests/dashboard/test_scanner_cache.py
+++ b/src/tests/dashboard/test_scanner_cache.py
@@ -1,0 +1,274 @@
+"""Unit tests for FennScanner caching (Pick 2) and running-session detection."""
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fenn.dashboard.scanner import FennScanner
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_COMPLETED_FN = """\
+<?xml version="1.0" encoding="utf-8"?>
+<fenn-log project="proj" session_id="{sid}" started="2026-05-21 08:00:00">
+  <config><item key="lr" value="0.01" /></config>
+  <entry ts="2026-05-21 08:00:00" kind="print" level="info">hello</entry>
+  <entry ts="2026-05-21 08:00:01" kind="print" level="warning">warn</entry>
+  <meta ended="2026-05-21 08:00:02" duration_s="2" status="completed" />
+</fenn-log>
+"""
+
+_RUNNING_FN = """\
+<?xml version="1.0" encoding="utf-8"?>
+<fenn-log project="proj" session_id="{sid}" started="2026-05-21 09:00:00">
+  <config><item key="lr" value="0.001" /></config>
+  <entry ts="2026-05-21 09:00:00" kind="print" level="info">started</entry>
+"""
+
+
+def _write(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Parse cache
+# ---------------------------------------------------------------------------
+
+
+class TestParseCache:
+    """FennScanner._parse_cache — hits, misses, and mtime invalidation."""
+
+    def test_first_parse_populates_cache(self, tmp_path):
+        """Parsing a file should store the result in _parse_cache."""
+        fn = _write(tmp_path / "s1.fn", _COMPLETED_FN.format(sid="s1"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        scanner.parse_fn_file(fn)
+
+        assert str(fn) in scanner._parse_cache
+
+    def test_cache_hit_reuses_result(self, tmp_path):
+        """Second call with same mtime must not re-read the file."""
+        fn = _write(tmp_path / "s1.fn", _COMPLETED_FN.format(sid="s1"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        first = scanner.parse_fn_file(fn)
+        # Overwrite with different content but keep mtime by faking it
+        orig_mtime = fn.stat().st_mtime
+
+        with patch.object(Path, "read_text", side_effect=AssertionError("should not read")):
+            # Inject a matching mtime so the cache is considered valid
+            scanner._parse_cache[str(fn)] = (orig_mtime, first)
+            second = scanner.parse_fn_file(fn)
+
+        assert second is not None
+        assert second["session_id"] == first["session_id"]
+
+    def test_mtime_change_invalidates_cache(self, tmp_path):
+        """Changing mtime should trigger a fresh parse."""
+        fn = _write(tmp_path / "s1.fn", _COMPLETED_FN.format(sid="s1"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+        scanner.parse_fn_file(fn)
+
+        # Rewrite with different content (changes mtime on real FS)
+        updated = _COMPLETED_FN.format(sid="s1").replace("hello", "world")
+        fn.write_text(updated, encoding="utf-8")
+
+        result = scanner.parse_fn_file(fn)
+
+        assert result is not None
+        entry_texts = [e["message"] for e in result["entries"]]
+        assert "world" in entry_texts
+
+    def test_missing_file_evicts_cache(self, tmp_path):
+        """Deleting a file should return None and evict the cache entry."""
+        fn = _write(tmp_path / "s1.fn", _COMPLETED_FN.format(sid="s1"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+        scanner.parse_fn_file(fn)
+        assert str(fn) in scanner._parse_cache
+
+        fn.unlink()
+        result = scanner.parse_fn_file(fn)
+
+        assert result is None
+        assert str(fn) not in scanner._parse_cache
+
+    def test_parse_extracts_counts(self, tmp_path):
+        """Parsed result should report correct warning and exception counts."""
+        content = """\
+<?xml version="1.0" encoding="utf-8"?>
+<fenn-log project="proj" session_id="cx" started="2026-05-21 08:00:00">
+  <entry ts="2026-05-21 08:00:00" kind="print" level="warning">w1</entry>
+  <entry ts="2026-05-21 08:00:01" kind="print" level="warning">w2</entry>
+  <entry ts="2026-05-21 08:00:02" kind="print" level="exception">ex1</entry>
+  <meta ended="2026-05-21 08:00:03" duration_s="3" status="completed" />
+</fenn-log>
+"""
+        fn = _write(tmp_path / "cx.fn", content)
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        result = scanner.parse_fn_file(fn)
+
+        assert result["warning_count"] == 2
+        assert result["exception_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Running → crashed re-evaluation
+# ---------------------------------------------------------------------------
+
+
+class TestRunningStatus:
+    """Running sessions flip to 'crashed' when mtime is stale."""
+
+    def test_fresh_running_stays_running(self, tmp_path):
+        """A recently-modified open file should stay 'running'."""
+        fn = _write(tmp_path / "r1.fn", _RUNNING_FN.format(sid="r1"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        with patch("fenn.dashboard.scanner._running_timeout_s", return_value=300.0):
+            with patch("fenn.dashboard.scanner.time") as mock_time:
+                mock_time.time.return_value = fn.stat().st_mtime + 10
+                result = scanner.parse_fn_file(fn)
+
+        assert result is not None
+        assert result["status"] == "running"
+
+    def test_stale_running_becomes_crashed(self, tmp_path):
+        """An open file untouched beyond the timeout should become 'crashed'."""
+        fn = _write(tmp_path / "r2.fn", _RUNNING_FN.format(sid="r2"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        with patch("fenn.dashboard.scanner._running_timeout_s", return_value=300.0):
+            with patch("fenn.dashboard.scanner.time") as mock_time:
+                mock_time.time.return_value = fn.stat().st_mtime + 400
+                result = scanner.parse_fn_file(fn)
+
+        assert result is not None
+        assert result["status"] == "crashed"
+
+    def test_cache_hit_still_checks_timeout(self, tmp_path):
+        """Even when the cache is valid, running status must be re-evaluated."""
+        fn = _write(tmp_path / "r3.fn", _RUNNING_FN.format(sid="r3"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+        mtime = fn.stat().st_mtime
+
+        # Prime cache with a "running" entry
+        with patch("fenn.dashboard.scanner._running_timeout_s", return_value=300.0):
+            with patch("fenn.dashboard.scanner.time") as mock_time:
+                mock_time.time.return_value = mtime + 10
+                scanner.parse_fn_file(fn)
+
+        assert scanner._parse_cache[str(fn)][1]["status"] == "running"
+
+        # Now time has advanced past the threshold — cache mtime unchanged
+        with patch("fenn.dashboard.scanner._running_timeout_s", return_value=300.0):
+            with patch("fenn.dashboard.scanner.time") as mock_time:
+                mock_time.time.return_value = mtime + 400
+                result = scanner.parse_fn_file(fn)
+
+        assert result["status"] == "crashed"
+        # The cached record itself must still say "running" (only the returned copy flips)
+        assert scanner._parse_cache[str(fn)][1]["status"] == "running"
+
+    def test_env_timeout_override(self, tmp_path, monkeypatch):
+        """FENN_RUNNING_TIMEOUT_S env var must change the crash threshold."""
+        monkeypatch.setenv("FENN_RUNNING_TIMEOUT_S", "60")
+        fn = _write(tmp_path / "r4.fn", _RUNNING_FN.format(sid="r4"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        with patch("fenn.dashboard.scanner.time") as mock_time:
+            mock_time.time.return_value = fn.stat().st_mtime + 90
+            result = scanner.parse_fn_file(fn)
+
+        assert result["status"] == "crashed"
+
+
+# ---------------------------------------------------------------------------
+# Directory listing cache (TTL)
+# ---------------------------------------------------------------------------
+
+
+class TestFileListingCache:
+    """find_fn_files() should cache directory scans for _FILES_CACHE_TTL_S."""
+
+    def test_listing_is_cached_within_ttl(self, tmp_path):
+        """Two rapid calls should return the same list object (cache hit)."""
+        _write(tmp_path / "s1.fn", _COMPLETED_FN.format(sid="s1"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        first = scanner.find_fn_files()
+        second = scanner.find_fn_files()
+
+        assert first is second  # same object == cache was reused
+
+    def test_listing_refreshes_after_ttl(self, tmp_path):
+        """After TTL expires a new scan should pick up added files."""
+        _write(tmp_path / "s1.fn", _COMPLETED_FN.format(sid="s1"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+        scanner.find_fn_files()
+
+        # Expire the cache manually
+        ts, files = scanner._files_cache
+        scanner._files_cache = (ts - 10.0, files)
+
+        _write(tmp_path / "s2.fn", _COMPLETED_FN.format(sid="s2"))
+        refreshed = scanner.find_fn_files()
+
+        assert any(p.stem == "s2" for p in refreshed)
+
+    def test_add_dir_invalidates_listing_cache(self, tmp_path):
+        """_add_dir() must invalidate _files_cache so the new dir is scanned."""
+        _write(tmp_path / "s1.fn", _COMPLETED_FN.format(sid="s1"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+        scanner.find_fn_files()
+        assert scanner._files_cache is not None
+
+        extra = tmp_path / "extra"
+        extra.mkdir()
+        scanner._add_dir(str(extra))
+
+        assert scanner._files_cache is None
+
+
+# ---------------------------------------------------------------------------
+# get_session short-circuit by filename stem
+# ---------------------------------------------------------------------------
+
+
+class TestGetSessionShortCircuit:
+    """get_session() should prefer the file whose stem matches session_id."""
+
+    def test_finds_session_by_stem(self, tmp_path):
+        """Session is resolved via stem match, not a full scan."""
+        _write(tmp_path / "sess_abc.fn", _COMPLETED_FN.format(sid="sess_abc"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        result = scanner.get_session("proj", "sess_abc")
+
+        assert result is not None
+        assert result["session_id"] == "sess_abc"
+
+    def test_returns_none_for_unknown_session(self, tmp_path):
+        """Non-existent session should return None."""
+        _write(tmp_path / "sess_abc.fn", _COMPLETED_FN.format(sid="sess_abc"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        result = scanner.get_session("proj", "no_such_session")
+
+        assert result is None
+
+    def test_session_includes_projects_list(self, tmp_path):
+        """Returned session dict must include the top-level 'projects' key."""
+        _write(tmp_path / "sess_abc.fn", _COMPLETED_FN.format(sid="sess_abc"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        result = scanner.get_session("proj", "sess_abc")
+
+        assert "projects" in result


### PR DESCRIPTION
- New crashed_sessions field in the /api/overview payload and crashed_count on each project entry.
- New "Crashed" stat card on the overview and project pages.
- Crashed badge (warning palette) in session tables and on the session detail page. Running and crashed branches added where only failed/completed existed. 
// create target directory when missing in fenn pull