### PR TITLE
XSS in search highlight, filter state lost on refresh, double scan on…

### DIFF
--- a/src/fenn/dashboard/scanner.py
+++ b/src/fenn/dashboard/scanner.py
@@ -239,11 +239,9 @@ class FennScanner:
                 sessions.append(parsed)
         return sessions
 
-    def get_overview(self) -> Dict[str, Any]:
-        """Aggregate stats for the dashboard home page."""
-        sessions = self.get_all_sessions()
-
-        # Group by project
+    @staticmethod
+    def _build_projects_list(sessions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Aggregate per-project stats from an already-loaded sessions list."""
         projects: Dict[str, Dict[str, Any]] = {}
         for s in sessions:
             name = s["project"]
@@ -265,25 +263,22 @@ class FennScanner:
                 p["running_count"] += 1
             elif s["status"] == "crashed":
                 p["crashed_count"] += 1
+        return sorted(projects.values(), key=lambda p: p["last_active"], reverse=True)
 
-        project_list = sorted(
-            projects.values(), key=lambda p: p["last_active"], reverse=True
-        )
-
-        total_warnings = sum(s["warning_count"] for s in sessions)
-        total_exceptions = sum(s["exception_count"] for s in sessions)
-        running = sum(1 for s in sessions if s["status"] == "running")
-        crashed = sum(1 for s in sessions if s["status"] == "crashed")
+    def get_overview(self) -> Dict[str, Any]:
+        """Aggregate stats for the dashboard home page."""
+        sessions = self.get_all_sessions()
+        project_list = self._build_projects_list(sessions)
 
         return {
             "projects": project_list,
             "recent_sessions": sessions[:20],
             "total_sessions": len(sessions),
-            "total_projects": len(projects),
-            "total_warnings": total_warnings,
-            "total_exceptions": total_exceptions,
-            "running_sessions": running,
-            "crashed_sessions": crashed,
+            "total_projects": len(project_list),
+            "total_warnings": sum(s["warning_count"] for s in sessions),
+            "total_exceptions": sum(s["exception_count"] for s in sessions),
+            "running_sessions": sum(1 for s in sessions if s["status"] == "running"),
+            "crashed_sessions": sum(1 for s in sessions if s["status"] == "crashed"),
             "active_page": "home",
         }
 
@@ -292,10 +287,8 @@ class FennScanner:
         all_sessions = self.get_all_sessions()
         sessions = [s for s in all_sessions if s["project"] == project_name]
 
-        overview = self.get_overview()
-
         return {
-            "projects": overview["projects"],
+            "projects": self._build_projects_list(all_sessions),
             "project_name": project_name,
             "sessions": sessions,
             "total_sessions": len(sessions),

--- a/src/fenn/dashboard/static/app.js
+++ b/src/fenn/dashboard/static/app.js
@@ -27,18 +27,26 @@
       }
     });
 
-    // Highlight search matches
+    // Highlight search matches — DOM-only to avoid XSS via innerHTML
     if (query) {
       document.querySelectorAll(".log-entry:not(.hidden) .log-msg").forEach((el) => {
         const text = el.textContent;
-        el.innerHTML = text.replace(
-          new RegExp(escapeRegex(query), "gi"),
-          (m) => `<span class="highlight">${m}</span>`
-        );
+        while (el.firstChild) el.removeChild(el.firstChild);
+        const regex = new RegExp(escapeRegex(query), "gi");
+        let last = 0, match;
+        while ((match = regex.exec(text)) !== null) {
+          if (match.index > last) el.appendChild(document.createTextNode(text.slice(last, match.index)));
+          const span = document.createElement("span");
+          span.className = "highlight";
+          span.textContent = match[0];
+          el.appendChild(span);
+          last = match.index + match[0].length;
+        }
+        if (last < text.length) el.appendChild(document.createTextNode(text.slice(last)));
       });
     } else {
-      document.querySelectorAll(".log-msg .highlight").forEach((el) => {
-        el.outerHTML = el.textContent;
+      document.querySelectorAll(".log-msg .highlight").forEach((span) => {
+        span.replaceWith(document.createTextNode(span.textContent));
       });
     }
 
@@ -136,16 +144,70 @@
     const project   = sessionStatus.dataset.project;
     const sessionId = sessionStatus.dataset.session;
 
+    function createEntryEl(entry) {
+      const row = document.createElement("div");
+      row.className = `log-entry level-${entry.level} kind-${entry.kind}`;
+      row.dataset.level = entry.level;
+      row.dataset.kind  = entry.kind;
+
+      const ts = document.createElement("span");
+      ts.className = "log-ts";
+      ts.textContent = entry.ts;
+
+      const kindWrap = document.createElement("span");
+      kindWrap.className = "log-kind";
+      const kindBadge = document.createElement("span");
+      kindBadge.className = `badge badge-${entry.kind}`;
+      kindBadge.style.fontSize = "10px";
+      kindBadge.textContent = entry.kind;
+      kindWrap.appendChild(kindBadge);
+
+      const levelWrap = document.createElement("span");
+      levelWrap.className = "log-level";
+      const levelBadge = document.createElement("span");
+      levelBadge.className = `badge badge-${entry.level}`;
+      levelBadge.style.fontSize = "10px";
+      levelBadge.textContent = entry.level;
+      levelWrap.appendChild(levelBadge);
+
+      const msg = document.createElement("span");
+      msg.className = "log-msg";
+      msg.textContent = entry.message;
+
+      row.append(ts, kindWrap, levelWrap, msg);
+      return row;
+    }
+
     function refresh() {
       fetch(`/api/session/${encodeURIComponent(project)}/${encodeURIComponent(sessionId)}`)
         .then((r) => (r.ok ? r.json() : null))
         .then((data) => {
           if (!data) return;
 
-          // Reload if status changed or entry count changed
-          const currentCount = document.querySelectorAll(".log-entry").length;
-          if (data.entry_count !== currentCount || data.status !== "running") {
+          // Status changed (e.g. running → completed/crashed) — full reload
+          // because the header badge and meta row need server-side re-render.
+          if (data.status !== "running") {
             location.reload();
+            return;
+          }
+
+          // New entries — append without disturbing filters or scroll position.
+          const currentCount = document.querySelectorAll(".log-entry").length;
+          if (data.entry_count !== currentCount && Array.isArray(data.entries)) {
+            const container = document.querySelector(".log-entries");
+            if (!container) return;
+            // Remove the "no entries" empty-state placeholder if present.
+            const empty = container.querySelector(".empty");
+            if (empty) empty.remove();
+            data.entries.slice(currentCount).forEach((entry) => {
+              const row = createEntryEl(entry);
+              // Respect current filter state so new rows appear/hide correctly.
+              if (levelState[entry.level] === false || kindState[entry.kind] === false) {
+                row.classList.add("hidden");
+              }
+              container.appendChild(row);
+            });
+            updateCount();
           }
         })
         .catch(() => {});


### PR DESCRIPTION
… project page

Pro 1 — Replace innerHTML highlight injection with DOM node construction (createTextNode + createElement) to prevent XSS from log message content.

Pro2 — Auto-refresh now appends new log entries to the DOM instead of calling location.reload(), so filters, search, and scroll are preserved. Full reload only when session status changes.

Pro3 — Extracted _build_projects_list(sessions) so get_project() calls get_all_sessions() once instead of twice per request.