### PR TITLE
docs(contributing): improve dev environment setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,19 @@ When you make changes, aim to:
 - Add or update tests and documentation if your change affects behavior or public APIs.
 - Keep commits logically grouped (for example, separate “refactor” from “new feature” where it makes sense).
 
-**Please note** that, in order to test your changes, you need to reinstall `fenn` locally in editable mode by running:
+**Please note** that, in order to test your changes, you need to reinstall `fenn` locally in editable mode along with its dev and test dependencies. `fenn` uses pre-commit and ruff for automated linting and formatting. From the base project directory (the one containing the project `pyproject.toml` file), run:
 
 ```
-pip install -e .
+pip install -e ".[dev,test]"
 ```
 
-from the base project directory (the one containing the project `pyproject.toml` file).
+### Set up pre-commit hooks
+
+Run `pre-commit install` to wire up the pre-commit git hook. This only needs to be done once after cloning your fork.
+
+This makes pre-commit run the configured hooks (`ruff check` and `ruff format` currently) on every `git commit`. Your commit may be blocked if a hook reports a failure or modifies a file. `ruff format` may reformat your code automatically, so you'll need to review the modifications and stage them again before committing. Without this step your commits may fail CI.
+
+See the [`ruff` documentation](https://docs.astral.sh/ruff/) for more information.
 
 Once your branch is ready:
 


### PR DESCRIPTION
Relates to #110.

## Changes

- Include dev and test extras in the install command for `fenn` editable install
- Add instructions for installing `pre-commit` hook and information on `pre-commit` and `ruff`

## Why

Observed the codebase has been failing `ruff` checks in CI intermittently, which points to a possible cause: contributors without the `pre-commit` hook installed pushing commits that haven't been linted or formatted locally. This change makes installation of dev dependencies explicit, so contributors have `pre-commit` and adds the missing instruction to install `pre-commit` hook. It also makes installing test deps obvious, since the existing docs encourage testing before committing.