### PR TITLE
feat: add dark mode support via prefers-color-scheme

### DIFF
--- a/src/fenn/dashboard/static/style.css
+++ b/src/fenn/dashboard/static/style.css
@@ -897,3 +897,52 @@ tr:hover td { background: var(--surface-2); }
   .sidebar { display: none; }
   .page { padding: 16px; }
 }
+/* ── Dark Mode ──────────────────────────────────────────── */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:           #0d1117;
+    --surface:      #161b22;
+    --surface-2:    #1c2128;
+    --surface-3:    #21262d;
+    --border:       #30363d;
+    --border-soft:  #21262d;
+
+    --sidebar-bg:       #161b22;
+    --sidebar-border:   #30363d;
+    --sidebar-text:     #e6edf3;
+    --sidebar-muted:    #8b949e;
+    --sidebar-dim:      #6e7681;
+    --sidebar-hover:    #1c2128;
+    --sidebar-active:   rgba(124, 58, 237, 0.15);
+
+    --topbar-bg:     #161b22;
+    --topbar-border: #30363d;
+
+    --text:          #e6edf3;
+    --text-muted:    #8b949e;
+    --text-dim:      #6e7681;
+
+    --info-bg:      rgba(9, 105, 218, 0.15);
+    --warning-bg:   rgba(154, 103, 0, 0.15);
+    --error-bg:     rgba(207, 34, 46, 0.15);
+    --success-bg:   rgba(26, 127, 55, 0.15);
+    --print-bg:     rgba(5, 80, 174, 0.12);
+
+    --shadow:    0 1px 3px rgba(0,0,0,.4), 0 4px 14px rgba(0,0,0,.3);
+    --shadow-sm: 0 1px 2px rgba(0,0,0,.4);
+    --shadow-card: 0 0 0 1px rgba(0,0,0,.3), 0 2px 8px rgba(0,0,0,.2);
+  }
+
+  .log-entries {
+    background: #0d1117;
+  }
+
+  .log-entry:hover {
+    background: #1c2128;
+  }
+
+  .search-input:focus {
+    background: #0d1117;
+  }
+}


### PR DESCRIPTION
## Summary
Adds automatic dark mode support to the Fenn dashboard frontend.

## Changes
- Added `@media (prefers-color-scheme: dark)` block to style.css
- Redefined all CSS variables for dark backgrounds and light text
- Updated log entries, search input and hover states for dark mode

## How it works
When a user's system is set to dark mode, the browser automatically
applies the dark color variables. No JavaScript required.

## Related Issue
Closes #114
Related to #98