### PR TITLE
chore: add typos to pre commit & resolve typos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Run unit tests with Pytest, Format + Lint checking with Ruff
+name: Tests and Pre-Commit Checks
 
 on:
   push:
@@ -38,7 +38,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  ruff:
+  pre-commit:
     runs-on: ubuntu-latest
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,8 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
+      
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.47.0
+    hooks:
+      - id: typos

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ When you make changes, aim to:
 - Add or update tests and documentation if your change affects behavior or public APIs.
 - Keep commits logically grouped (for example, separate “refactor” from “new feature” where it makes sense).
 
-**Please note** that, in order to test your changes, you need to reinstall `fenn` locally in editable mode along with its dev and test dependencies. `fenn` uses pre-commit and ruff for automated linting and formatting. From the base project directory (the one containing the project `pyproject.toml` file), run:
+**Please note** that, in order to test your changes, you need to reinstall `fenn` locally in editable mode along with its dev and test dependencies. `fenn` uses pre-commit, ruff, and typos for automated linting, formatting, and spell checking. From the base project directory (the one containing the project `pyproject.toml` file), run:
 
 ```
 pip install -e ".[dev,test]"
@@ -47,9 +47,11 @@ pip install -e ".[dev,test]"
 
 Run `pre-commit install` to wire up the pre-commit git hook. This only needs to be done once after cloning your fork.
 
-This makes pre-commit run the configured hooks (`ruff check` and `ruff format` currently) on every `git commit`. Your commit may be blocked if a hook reports a failure or modifies a file. `ruff format` may reformat your code automatically, so you'll need to review the modifications and stage them again before committing. Without this step your commits may fail CI.
+This makes pre-commit run the configured hooks on every `git commit`. Your commit may be blocked if a hook reports a failure or modifies a file. `ruff format` may reformat your code automatically, so you'll need to review the modifications and stage them again before committing. Without this step your commits may fail CI.
 
-See the [`ruff` documentation](https://docs.astral.sh/ruff/) for more information.
+For more information on `ruff` and `typos` see the docs:
+- [`ruff` documentation](https://docs.astral.sh/ruff/)
+- [`typos` documentation](https://github.com/crate-ci/typos)
 
 Once your branch is ready:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,3 +118,12 @@ exclude = ["src/fenn/experimental/*"]
 
 [tool.ruff]
 include = ["pyproject.toml", "src/**/*.py"]
+
+[tool.typos.files]
+extend-exclude = [
+  "uv.lock",
+  "experimental/"
+]
+
+[tool.typos.default.extend-words]
+certifi = "certifi"

--- a/src/fenn/args/parser.py
+++ b/src/fenn/args/parser.py
@@ -36,7 +36,7 @@ class Parser:
         logger = Logger()
 
         if not os.path.isfile(self._config_file):
-            logger.display_excpetion(
+            logger.display_exception(
                 f"Configuration file {self._config_file} was not found."
             )
 

--- a/src/fenn/cli/__init__.py
+++ b/src/fenn/cli/__init__.py
@@ -2,10 +2,10 @@ import argparse
 
 import fenn.cli.auth as auth
 import fenn.cli.dashboard as dashboard
+import fenn.cli.grid as grid
 import fenn.cli.list as list
 import fenn.cli.pull as pull
 import fenn.cli.run as run
-import fenn.cli.grid as grid
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -144,9 +144,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--profile", default=None, help="Profile name (default: 'default')"
     )
     p_logout.set_defaults(func=auth.execute)
-    
+
     # ========= GRID =========
-    
+
     p_grid = subparsers.add_parser(
         "grid",
         help="Run a Fenn project several times, with all possible grid hyperparams",

--- a/src/fenn/cli/grid.py
+++ b/src/fenn/cli/grid.py
@@ -1,17 +1,15 @@
 import argparse
-from itertools import product
 import os
+import shutil
 import subprocess
 import sys
-import shutil
-
-from colorama import Fore, Style
+from itertools import product
 from pathlib import Path
 
 import yaml
+from colorama import Fore, Style
 
 from fenn.args.parser import Parser
-
 
 
 def execute(args: argparse.Namespace) -> None:
@@ -34,17 +32,21 @@ def execute(args: argparse.Namespace) -> None:
     shutil.copy(yaml_path, yaml_copy)
     try:
         for hyperparameter in parsed_grid:
-            _execute_fenn(hyperparameter=hyperparameter,
-                        main_path=main_path,
-                        yaml_path=yaml_path)
+            _execute_fenn(
+                hyperparameter=hyperparameter, main_path=main_path, yaml_path=yaml_path
+            )
     finally:
         shutil.copy(yaml_copy, yaml_path)
         os.remove(yaml_copy)
 
+
 def _build_variants(raw_grid: dict[str, list | int]) -> list[dict[str, int]]:
     keys = raw_grid.keys()
-    values: list[list | list[int]] = [v if isinstance(v, list) else [v] for v in raw_grid.values()]
+    values: list[list | list[int]] = [
+        v if isinstance(v, list) else [v] for v in raw_grid.values()
+    ]
     return [dict(zip(keys, combo)) for combo in product(*values)]
+
 
 def _parse_grid(yaml_path: Path) -> list[dict[str, int]]:
     parsed_yaml = Parser(config_file=yaml_path).load_configuration()
@@ -52,14 +54,15 @@ def _parse_grid(yaml_path: Path) -> list[dict[str, int]]:
         raise TemplateError
     return _build_variants(raw_grid=parsed_yaml.get("grid").get("train"))
 
-def _execute_fenn(hyperparameter: dict[str: int],
-                  main_path: Path,
-                  yaml_path: Path) -> None:
+
+def _execute_fenn(
+    hyperparameter: dict[str:int], main_path: Path, yaml_path: Path
+) -> None:
     with open(yaml_path, "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
     train_data = config["train"]
     for key, value in hyperparameter.items():
-        train_data.update({key:value})
+        train_data.update({key: value})
     with open(yaml_path, "w", encoding="utf-8") as f:
         yaml.dump(config, f, allow_unicode=True, default_flow_style=False)
     subprocess.run(["python3", main_path], cwd=main_path.parent)

--- a/src/fenn/logging/logger.py
+++ b/src/fenn/logging/logger.py
@@ -77,7 +77,7 @@ class Logger:
         if self._args:
             self._fnxml_backend.system_info(message)
 
-    def display_excpetion(
+    def display_exception(
         self, message: str, display_on_terminal=True, write_on_file=True
     ) -> None:
         self._logging_backend.exception(message, display_on_terminal, write_on_file)

--- a/src/tests/cli/test_grid_command.py
+++ b/src/tests/cli/test_grid_command.py
@@ -1,19 +1,21 @@
 "Test for `fenn grid` command."
 
-
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
+
+import pytest
 
 from fenn.args.parser import Parser
 from fenn.cli import build_parser
 from fenn.cli.grid import TemplateError, _build_variants, _execute_fenn, _parse_grid
-import pytest
+
 
 def test_grid_parser_defaults() -> None:
     parser: ArgumentParser = build_parser()
     args: Namespace = parser.parse_args(["grid"])
     assert args.command == "grid"
     assert args.path is None
+
 
 def test_run_parser_collects_includes_and_excludes() -> None:
     parser: ArgumentParser = build_parser()
@@ -25,6 +27,7 @@ def test_run_parser_collects_includes_and_excludes() -> None:
     )
     assert args.path == "main.py"
 
+
 def test_cartesian_product() -> None:
     expected_result: list[dict[str, int]] = [
         {"seed": 42, "batch": 16, "epochs": 30, "lr": 1e-3},
@@ -32,14 +35,17 @@ def test_cartesian_product() -> None:
         {"seed": 42, "batch": 15, "epochs": 30, "lr": 1e-3},
         {"seed": 41, "batch": 15, "epochs": 30, "lr": 1e-3},
     ]
-    test_dict: dict[str: list[int] | int] = {"seed": [42,41],
-                                             "batch": [16,15],
-                                             "epochs": 30,
-                                             "lr": 1e-3}
+    test_dict: dict[str : list[int] | int] = {
+        "seed": [42, 41],
+        "batch": [16, 15],
+        "epochs": 30,
+        "lr": 1e-3,
+    }
     test_result: list[dict[str, int]] = _build_variants(test_dict)
     assert len(test_result) == 4
     for variant in expected_result:
         assert variant in test_result
+
 
 def test_template_error(monkeypatch) -> None:
     monkeypatch.setattr(Parser, "_instance", None)
@@ -47,13 +53,11 @@ def test_template_error(monkeypatch) -> None:
     with pytest.raises(TemplateError):
         _parse_grid(yaml)
 
+
 def test_execution(monkeypatch) -> None:
     monkeypatch.setattr(Parser, "_instance", None)
     yaml: Path = Path("src/tests/templates/with_grid/fenn.yaml")
     main: Path = Path("src/tests/templates/with_grid/main.py")
     hyperparams: list[dict[str, int]] = _parse_grid(yaml)
     for hyperparameter in hyperparams:
-        _execute_fenn(hyperparameter=hyperparameter,
-                      main_path=main,
-                      yaml_path=yaml)
-    
+        _execute_fenn(hyperparameter=hyperparameter, main_path=main, yaml_path=yaml)

--- a/src/tests/templates/default/main.py
+++ b/src/tests/templates/default/main.py
@@ -2,6 +2,7 @@ from fenn import Fenn
 
 app = Fenn()
 
+
 @app.entrypoint
 def main(args):
     # 'args' contains your fenn.yaml configurations
@@ -9,6 +10,7 @@ def main(args):
     print(f"Training with seed: {args['train']['seed']}")
     print(f"Training with batch: {args['train']['batch']}")
     # Your logic here...
+
 
 if __name__ == "__main__":
     app.run()

--- a/src/tests/templates/with_grid/main.py
+++ b/src/tests/templates/with_grid/main.py
@@ -2,6 +2,7 @@ from fenn import Fenn
 
 app = Fenn()
 
+
 @app.entrypoint
 def main(args):
     # 'args' contains your fenn.yaml configurations
@@ -9,6 +10,7 @@ def main(args):
     print(f"Training with seed: {args['train']['seed']}")
     print(f"Training with batch: {args['train']['batch']}")
     # Your logic here...
+
 
 if __name__ == "__main__":
     app.run()


### PR DESCRIPTION
Relates to #122. I'll open a second PR for implementing `typos` on the docs repo and applying any fixes.

## Changes

- Added `typos` to pre-commit and project tools
- Renamed `Logger.display_excpetion` to `Logger.display_exception` (method name was misspelled)
- Updated `CONTRIBUTING.md` to flag use of `typos` and link to official docs
- Ran `pre-commit run --all-files` to auto fix `ruff` failures across the repo (very minor fixes)

## Notes

Check `pyproject.toml` file to acknowledge typos being ignored:
- Excluded `uv.lock` from typos scanning to avoid false positives on hashes (currently clean)
- Excluded `experimental/` from typos scanning to match `ruff` pattern
- Allow listed `certifi`, which is a valid spelling of the Certifi Mozilla package not a typo
