### PR TITLE
Add zizmor to audit GitHub Actions

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,3 +24,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          inputs: .github/workflows

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
## Summary

Closes #120

Adds zizmor security auditing for GitHub Actions workflows.

## Changes

- Added a zizmor GitHub Actions workflow
- Enables automated detection of CI/CD security issues
- Uses minimal workflow permissions
- Pins GitHub Actions dependencies by commit hash

## Validation

Tested the workflow successfully on my fork before opening this PR.

The zizmor workflow detected GitHub Actions security findings including:
- unpinned action references
- overly broad permissions
- checkout credential persistence risks