### PR TITLE
fix: harden GitHub Actions security configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -43,7 +45,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -14,9 +17,9 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-          
+
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: "3.12"
 
@@ -30,13 +33,13 @@ jobs:
           pytest --cov --cov-branch --cov-report=xml
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@968872560f81e7bdde9272853e65f2507c0eca7c # v5.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@1b5b448b98e58ba90d1a1a1d9fcb72ca2263be46 # v1.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -50,7 +53,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary

Fixes #130

Fixes the GitHub Actions security issues detected by zizmor.

This PR hardens the existing CI workflow by addressing:

- `zizmor/unpinned-uses`
  - Replaced mutable action version tags with immutable commit SHA references.
  - This prevents a compromised/moved tag from changing the executed workflow code.

- `zizmor/artipacked`
  - Disabled credential persistence for checkout steps using:
    ```yaml
    persist-credentials: false
    ```
  - Prevents unnecessary Git credential exposure after repository checkout.

- `zizmor/excessive-permissions`
  - Added explicit least-privilege workflow permissions:
    ```yaml
    permissions:
      contents: read
    ```
  - Avoids relying on default GitHub token permissions.

## Pinned GitHub Action References

The following actions were pinned to their corresponding release commits:

| Action | Version | Commit SHA |
|---|---|---|
| actions/checkout | v5.0.0 | `08c6903cd8c0fde910a37f88322edcfb5dd907a8` |
| actions/setup-python | v5.0.0 | `0a5c61591373683505ea898e09a3ea4f39ef2b9c` |
| codecov/codecov-action | v5.0.0 | `968872560f81e7bdde9272853e65f2507c0eca7c` |
| codecov/test-results-action | v1.0.0 | `1b5b448b98e58ba90d1a1a1d9fcb72ca2263be46` |

The SHA values correspond to the official release commits/tags from their respective repositories.

## Testing

- Verified workflow syntax after security changes.
- Changes are limited to GitHub Actions hardening and do not modify application or test logic.