### PR TITLE
ci: add GitHub Actions workflow to publish to PyPI on new release (#125)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,63 @@
+---
+name: "Publish Python Package to PyPI on new Release"
+
+"on":
+  release:
+    types: ["created"]
+
+env:
+  UV_PYTHON_DOWNLOADS: 0
+
+jobs:
+  build:
+    name: "Build distribution"
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: "Set up Python 3.12"
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: false
+
+      - name: "Build"
+        run: uv build
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/*
+
+  publish:
+    name: "Publish to PyPI"
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: "Download artifact"
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: false
+
+      - name: "Publish"
+        run: uv publish


### PR DESCRIPTION
Closes #125

## What this PR does
Adds a GitHub Actions workflow that automatically builds and publishes fenn to PyPI whenever a new GitHub Release is created.

## How it works
1. Triggers on `release: created`
2. Builds the package using `uv build` (produces `.whl` and `.tar.gz`)
3. Publishes to PyPI using `uv publish` with trusted publishing (no API key needed)

## Setup required
Before this workflow can publish successfully, a maintainer needs to:
1. Go to repository **Settings → Environments** and create an environment named `pypi`
2. Configure trusted publishing on PyPI at [pypi.org/manage/account/publishing](https://pypi.org/manage/account/publishing) with:
   - Repository: `pyfenn/fenn`
   - Workflow: `publish.yaml`
   - Environment: `pypi`

## Testing
The build step was verified locally with `uv build` — successfully produced `fenn-0.2.1.tar.gz` and `fenn-0.2.1-py3-none-any.whl`.