### PR TITLE
feat: add hamburger menu toggle for mobile sidebar (#142)

### DIFF
--- a/fenn/dashboard/static/app.js
+++ b/fenn/dashboard/static/app.js
@@ -269,6 +269,38 @@
       document.activeElement?.blur();
     }
   });
+  // ── Sidebar hamburger toggle ───────────────────────────────────────────── //
+
+  const sidebarToggle = document.getElementById("sidebar-toggle");
+  const sidebar = document.getElementById("sidebar");
+
+  if (sidebarToggle && sidebar) {
+    sidebarToggle.addEventListener("click", () => {
+      const isOpen = sidebar.classList.toggle("open");
+      sidebarToggle.classList.toggle("is-open", isOpen);
+    });
+
+    // Close sidebar when clicking a nav item on mobile
+    sidebar.querySelectorAll(".nav-item").forEach((item) => {
+      item.addEventListener("click", () => {
+        if (window.innerWidth <= 600) {
+          sidebar.classList.remove("open");
+          sidebarToggle.classList.remove("is-open");
+        }
+      });
+    });
+
+    // Close sidebar when clicking outside
+    document.addEventListener("click", (e) => {
+      if (window.innerWidth <= 600 &&
+          sidebar.classList.contains("open") &&
+          !sidebar.contains(e.target) &&
+          !sidebarToggle.contains(e.target)) {
+        sidebar.classList.remove("open");
+        sidebarToggle.classList.remove("is-open");
+      }
+    });
+  }
 
   // ── Init ───────────────────────────────────────────────────────────────── //
 

--- a/fenn/dashboard/static/style.css
+++ b/fenn/dashboard/static/style.css
@@ -804,6 +804,55 @@ mark, .log-msg .hl, .log-msg .highlight {
   color: var(--text-fade);
 }
 
+/* ── Hamburger menu ─────────────────────────────────────────────────── */
+.hamburger {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  margin-right: 12px;
+}
+.hamburger span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: var(--text-mute);
+  border-radius: 2px;
+  transition: background .15s;
+}
+.hamburger:hover span { background: var(--accent); }
+.hamburger.is-open span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+.hamburger.is-open span:nth-child(2) {
+  opacity: 0;
+}
+.hamburger.is-open span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+.hamburger span {
+  transition: transform .2s, opacity .2s, background .15s;
+}
+
+@media (max-width: 600px) {
+  .hamburger { display: flex; }
+  .sidebar {
+    display: none;
+    width: 100%;
+    position: fixed;
+    top: 56px;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 9;
+    overflow-y: auto;
+  }
+  .sidebar.open { display: flex; }
+}
+
 /* ── Responsive ────────────────────────────────────────────────────── */
 @media (max-width: 860px) {
   .log-entry {

--- a/fenn/dashboard/templates/base.html
+++ b/fenn/dashboard/templates/base.html
@@ -15,7 +15,7 @@
 <div class="layout">
 
   <!-- ── Sidebar ──────────────────────────────────────────────────────── -->
-  <aside class="sidebar">
+  <aside class="sidebar" id="sidebar">
     <div class="sidebar-header">
       <img src="{{ url_for('static', filename='images/icon.png') }}"
            alt="fenn"
@@ -57,6 +57,9 @@
   <div class="main">
 
     <header class="topbar">
+      <button class="hamburger" id="sidebar-toggle" aria-label="Toggle navigation">
+        <span></span><span></span><span></span>
+      </button>
       <div class="breadcrumb">
         {% block breadcrumb %}{% endblock %}
       </div>


### PR DESCRIPTION
Closes #142
Part of #98

## Problem
On mobile screens (≤600px), the sidebar stacked on top of the main content with no way to hide it, forcing users to scroll past the entire navigation before seeing any dashboard content.

## Solution
Added a hamburger menu button (≡) to the topbar that toggles the sidebar on mobile.

## Changes
- `base.html` — added hamburger button to topbar, added `id="sidebar"` to aside
- `style.css` — hamburger button styles, mobile sidebar toggle, X animation
- `app.js` — toggle logic, closes on outside click, closes on nav item click

## Behaviour
- Sidebar hidden by default on mobile (≤600px)
- Hamburger (≡) visible in topbar on mobile only
- Click hamburger → sidebar slides in below topbar
- Hamburger animates to X (✕) when sidebar is open
- Click outside or click a nav item → sidebar closes
- No changes to desktop layout

## Screenshots

### Sidebar closed
<img width="349" height="633" alt="image" src="https://github.com/user-attachments/assets/5dd75c78-c87e-4fa7-b34c-783bbb785006" />

### Sidebar open
<img width="354" height="631" alt="image" src="https://github.com/user-attachments/assets/bd5e141d-ed28-48e7-86ff-99ffe604a475" />