### PR TITLE
ci: test against Python 3.11, 3.12, and 3.13(#124)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Tests and Pre-Commit Checks
 
 on:
   push:
-    branches: [python-versions]
+    branches: [main]
   pull_request:
 
 permissions:
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Tests and Pre-Commit Checks
 
 on:
   push:
-    branches: [main]
+    branches: [python-versions]
   pull_request:
 
 permissions:
@@ -11,6 +11,10 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout
@@ -21,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install package and test deps
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout

--- a/fenn/remote/credentials.py
+++ b/fenn/remote/credentials.py
@@ -24,10 +24,11 @@ from __future__ import annotations
 
 import os
 import sys
-import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional
+
+import tomllib
 
 from fenn.remote.exceptions import CredentialsError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "python-dotenv>=1.2.2",
 ]
 
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "python-dotenv>=1.2.2",
 ]
 
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [project.optional-dependencies]
 


### PR DESCRIPTION
Issue #124

## Changes
Added a version matrix to the test job in ci.yaml to run tests across Python 3.11, 3.12, and 3.13.

For 3.10 tomllib is not available.
For 3.14 there are some numpy compatibility issues.