### PR TITLE
feat: improve mobile responsiveness of dashboard

### DIFF
--- a/fenn/dashboard/static/style.css
+++ b/fenn/dashboard/static/style.css
@@ -916,4 +916,53 @@ mark, .log-msg .hl, .log-msg .highlight {
   .search-input:focus {
     background: #0d1117;
   }
+}/* ── Mobile Responsiveness Improvements ────────────────────────────── */
+
+@media (max-width: 600px) {
+  .log-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .search-wrap {
+    width: 100%;
+  }
+  .search-input {
+    width: 100%;
+  }
+  .log-count {
+    margin-left: 0;
+  }
+  .filter-group {
+    flex-wrap: wrap;
+  }
+  .page-404 .code {
+    font-size: 52px;
+  }
+  .page-404 .msg {
+    font-size: 16px;
+  }
+  .stats-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .section-header {
+    flex-direction: column;
+    gap: 8px;
+  }
+  .meta-row {
+    gap: 10px;
+    padding: 10px 14px;
+    font-size: 11px;
+  }
+}
+
+@media (max-width: 380px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+  .page-title {
+    font-size: 22px;
+  }
+  .stat-value {
+    font-size: 20px;
+  }
 }


### PR DESCRIPTION
Closes #160

## Changes
- Log toolbar stacks vertically on mobile, search bar stretches full width
- Filter group wraps on small screens
- 404 page font size reduced (88px → 52px) for mobile
- Stats grid: 2-column on mobile, 1-column on very small screens (< 380px)
- Section header stacks vertically on mobile
- Meta row: tighter padding and font size on mobile

## Files modified
- `fenn/dashboard/static/style.css`