### PR TITLE
fix: restore print after fenn run

### DIFF
--- a/fenn/core/fenn.py
+++ b/fenn/core/fenn.py
@@ -7,7 +7,7 @@ from fenn.args import Parser
 from fenn.export.exporter import Exporter
 from fenn.secrets.keystore import KeyStore
 from fenn.utils import generate_session_id
-from fenn.utils.logging import logger, original_print
+from fenn.utils.logging import logger, original_print, redirect_prints, restore_prints
 
 
 class Fenn:
@@ -105,12 +105,13 @@ class Fenn:
                 "to register your main function."
             )
 
-        Exporter().configure(self._args)
-
-        # Print parsed config (user logs)
-        self._parser.print()
-
+        redirect_prints()
         try:
+            Exporter().configure(self._args)
+
+            # Print parsed config (user logs)
+            self._parser.print()
+
             # System startup message
             logger.info(
                 f"Application starting from entrypoint: {self._entrypoint_fn.__name__}"
@@ -121,6 +122,7 @@ class Fenn:
             return result
 
         finally:
+            restore_prints()
             logger.close()
 
     def disable_disclaimer(self) -> None:

--- a/fenn/utils/logging.py
+++ b/fenn/utils/logging.py
@@ -143,6 +143,8 @@ class FennLogger(XmlMixin, logging.LoggerAdapter):
 
     def close(self):
         self._write_stop_info(started_at=self._started_at)
+        self.handler._log_file = None
+        self.handler._fn_xml = None
 
     def process(self, msg, kwargs):
         kwargs["extra"] = {**self.extra, **kwargs.get("extra", {})}
@@ -226,4 +228,11 @@ def _custom_print(*args, **kwargs):
 
 
 original_print = builtins.print
-builtins.print = _custom_print
+
+
+def redirect_prints() -> None:
+    builtins.print = _custom_print
+
+
+def restore_prints() -> None:
+    builtins.print = original_print

--- a/tests/unit/test_print_redirection.py
+++ b/tests/unit/test_print_redirection.py
@@ -1,0 +1,49 @@
+import builtins
+
+import pytest
+
+from fenn import Fenn
+from fenn.utils.logging import original_print
+
+
+def _write_config(path):
+    path.write_text(
+        "session_id: test-session\nlogger:\n  dir: logs\nexport:\n  dir: exports\n",
+        encoding="utf-8",
+    )
+
+
+def test_print_is_restored_after_entrypoint_exception(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path / "fenn.yaml")
+
+    app = Fenn()
+    app.disable_disclaimer()
+
+    @app.entrypoint
+    def main(args):
+        assert builtins.print is not original_print
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        app.run()
+
+    assert builtins.print is original_print
+
+
+def test_print_is_restored_after_successful_run(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path / "fenn.yaml")
+
+    app = Fenn()
+    app.disable_disclaimer()
+
+    @app.entrypoint
+    def main(args):
+        assert builtins.print is not original_print
+        print("captured by fenn logger")
+        return "ok"
+
+    assert app.run() == "ok"
+
+    assert builtins.print is original_print


### PR DESCRIPTION
## What does this PR do?
Restores Python's original `print` after `Fenn.run()` finishes, including when the entrypoint raises unexpectedly. User `print()` calls are still captured by the Fenn logger while the entrypoint is running, but exception handlers and code after `run()` now use normal stdout behavior again.

This also clears the configured log file paths when the logger closes so later standalone CLI logging cannot write to stale per-run files.

## Issue link
Fixes #171

## Checklist before merging
- [x] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Each commit represents a single, coherent unit of work
- [x] My changes are covered by unit tests
- [x] Unit tests successfully run locally
- [x] I have formatted Python code with the configured formatter
- [x] I have checked static type hinting with the configured pre-commit hook
- [ ] I have added/updated necessary documentation, if required
- [x] I have checked for and resolved any merge conflicts
- [x] I have performed a self-review of my code

## Additional notes
Validation run:
- `python -m pytest tests/unit/test_print_redirection.py tests/unit/cli/test_run_command.py tests/unit/utils/test_utils.py -q` — 16 passed
- `python -m pytest tests/unit -q --ignore=tests/unit/vision --ignore=tests/unit/nn` — 411 passed, 1 skipped
- `pre-commit run --files fenn/utils/logging.py fenn/core/fenn.py tests/unit/test_print_redirection.py` — passed
- `git diff --cached --check` — passed before commit
