### PR TITLE
Fix(Dashboard): Use missing `--debug` argument to change log level

### DIFF
--- a/fenn/cli/__init__.py
+++ b/fenn/cli/__init__.py
@@ -58,7 +58,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_dash.add_argument(
         "--port", type=int, default=5000, help="Port to bind (default: 5000)"
     )
-    p_dash.add_argument("--debug", action="store_true", help="Run Flask in debug mode")
+    p_dash.add_argument("--debug", action="store_true", help="Run in debug mode")
     p_dash.set_defaults(func=dashboard.execute)
 
     # ========= RUN =========

--- a/fenn/dashboard/app.py
+++ b/fenn/dashboard/app.py
@@ -1,6 +1,7 @@
 """Fenn Dashboard — Flask application for browsing fnxml log files."""
 
 import argparse
+import logging
 import secrets
 from datetime import timedelta
 from pathlib import Path
@@ -333,13 +334,15 @@ def logout():
 # --------------------------------------------------------------------------- #
 
 
-# TODO: Use 'debug' in logger
 def run(
     host: str = "127.0.0.1", port: int = 5000, debug: bool = False, log_dirs=None
 ) -> None:
     """Configure and start the dashboard server."""
     if log_dirs:
         scanner.add_dirs(log_dirs)
+    log_level = logging.DEBUG if debug else logging.INFO
+    app.logger.setLevel(log_level)
+    logger.setLevel(log_level)
     logger.info(f"Fenn dashboard started at http://{host}:{port}")
     from werkzeug.serving import make_server
 


### PR DESCRIPTION
As described in #155 (I didn't get a comment about it  there, so I'll be happy to hear and apply your thoughts here), fixes missing handling of `--debug` argument in `fenn dashboard`. Applies to `app.logger` (Flask level) and `logger` (fenn level). Tested manually and with unit tests.

Before:
- `fenn dashboard` -> All logs (including DEBUGs, for both Flask internals and dashboard)
- `fenn dashboard --debug` -> All logs (including DEBUGs, for both Flask internals and dashboard)

After:
- `fenn dashboard` -> INFO and above (for both Flask internals and dashboard)
- `fenn dashboard --debug` -> DEBUG and above (All logs, for both Flask internals and dashboard)

Also fixed command help to accurate behavior and removed `# TODO`.