### PR TITLE
Refactor(Types): Update type hints to 3.9+ (3.10+) style

### DIFF
--- a/fenn/agents/__init__.pyi
+++ b/fenn/agents/__init__.pyi
@@ -1,17 +1,18 @@
-from typing import Any, Dict, Generic, Iterator, List, Optional, TypeVar, Union
+from collections.abc import Iterator
+from typing import Any, Generic, TypeVar
 
 _PrepResult = TypeVar("_PrepResult")
 _ExecResult = TypeVar("_ExecResult")
 _PostResult = TypeVar("_PostResult")
 
-ParamValue = Union[str, int, float, bool, None, List[Any], Dict[str, Any]]
-SharedData = Dict[str, Any]
-Params = Dict[str, ParamValue]
-Messages = List[Dict[str, str]]
+ParamValue = str | int | float | bool | None | list[Any] | dict[str, Any]
+SharedData = dict[str, Any]
+Params = dict[str, ParamValue]
+Messages = list[dict[str, str]]
 
 class BaseNode(Generic[_PrepResult, _ExecResult, _PostResult]):
     params: Params
-    successors: Dict[str, Any]
+    successors: dict[str, Any]
 
     def __init__(self) -> None: ...
     def set_params(self, params: Params) -> None: ...
@@ -26,37 +27,37 @@ class BaseNode(Generic[_PrepResult, _ExecResult, _PostResult]):
 
 class Node(BaseNode[_PrepResult, _ExecResult, _PostResult]):
     max_retries: int
-    wait: Union[int, float]
+    wait: int | float
     cur_retry: int
 
-    def __init__(self, max_retries: int = 1, wait: Union[int, float] = 0) -> None: ...
+    def __init__(self, max_retries: int = 1, wait: int | float = 0) -> None: ...
     def exec_fallback(self, prep_res: _PrepResult, exc: Exception) -> _ExecResult: ...
     def _exec(self, prep_res: _PrepResult) -> _ExecResult: ...
 
-class BatchNode(Node[Optional[List[_PrepResult]], List[_ExecResult], _PostResult]):
-    def _exec(self, items: Optional[List[_PrepResult]]) -> List[_ExecResult]: ...
+class BatchNode(Node[list[_PrepResult] | None, list[_ExecResult], _PostResult]):
+    def _exec(self, items: list[_PrepResult] | None) -> list[_ExecResult]: ...
 
 class Flow(BaseNode[_PrepResult, Any, _PostResult]):
-    start_node: Optional[BaseNode[Any, Any, Any]]
+    start_node: BaseNode[Any, Any, Any] | None
 
-    def __init__(self, start: Optional[BaseNode[Any, Any, Any]] = None) -> None: ...
+    def __init__(self, start: BaseNode[Any, Any, Any] | None = None) -> None: ...
     def start(self, start: BaseNode[Any, Any, Any]) -> BaseNode[Any, Any, Any]: ...
     def connect(
         self,
         src: BaseNode[Any, Any, Any],
-        dst: Optional[BaseNode[Any, Any, Any]],
+        dst: BaseNode[Any, Any, Any] | None,
         action: str = "default",
     ) -> "Flow[_PrepResult, _PostResult]": ...
     def get_next_node(
-        self, curr: BaseNode[Any, Any, Any], action: Optional[str]
-    ) -> Optional[BaseNode[Any, Any, Any]]: ...
-    def _orch(self, shared: SharedData, params: Optional[Params] = None) -> Any: ...
+        self, curr: BaseNode[Any, Any, Any], action: str | None
+    ) -> BaseNode[Any, Any, Any] | None: ...
+    def _orch(self, shared: SharedData, params: Params | None = None) -> Any: ...
     def _run(self, shared: SharedData) -> _PostResult: ...
     def post(
         self, shared: SharedData, prep_res: _PrepResult, exec_res: Any
     ) -> _PostResult: ...
 
-class BatchFlow(Flow[Optional[List[Params]], Any, _PostResult]):
+class BatchFlow(Flow[list[Params] | None, Any, _PostResult]):
     def _run(self, shared: SharedData) -> _PostResult: ...
 
 class AsyncNode(Node[_PrepResult, _ExecResult, _PostResult]):
@@ -74,22 +75,22 @@ class AsyncNode(Node[_PrepResult, _ExecResult, _PostResult]):
     def _run(self, shared: SharedData) -> _PostResult: ...
 
 class AsyncBatchNode(
-    AsyncNode[Optional[List[_PrepResult]], List[_ExecResult], _PostResult],
-    BatchNode[Optional[List[_PrepResult]], List[_ExecResult], _PostResult],
+    AsyncNode[list[_PrepResult] | None, list[_ExecResult], _PostResult],
+    BatchNode[list[_PrepResult] | None, list[_ExecResult], _PostResult],
 ):
-    async def _exec(self, items: Optional[List[_PrepResult]]) -> List[_ExecResult]: ...
+    async def _exec(self, items: list[_PrepResult] | None) -> list[_ExecResult]: ...
 
 class AsyncParallelBatchNode(
-    AsyncNode[Optional[List[_PrepResult]], List[_ExecResult], _PostResult],
-    BatchNode[Optional[List[_PrepResult]], List[_ExecResult], _PostResult],
+    AsyncNode[list[_PrepResult] | None, list[_ExecResult], _PostResult],
+    BatchNode[list[_PrepResult] | None, list[_ExecResult], _PostResult],
 ):
-    async def _exec(self, items: Optional[List[_PrepResult]]) -> List[_ExecResult]: ...
+    async def _exec(self, items: list[_PrepResult] | None) -> list[_ExecResult]: ...
 
 class AsyncFlow(
     Flow[_PrepResult, Any, _PostResult], AsyncNode[_PrepResult, Any, _PostResult]
 ):
     async def _orch_async(
-        self, shared: SharedData, params: Optional[Params] = None
+        self, shared: SharedData, params: Params | None = None
     ) -> Any: ...
     async def _run_async(self, shared: SharedData) -> _PostResult: ...
     async def post_async(
@@ -97,14 +98,14 @@ class AsyncFlow(
     ) -> _PostResult: ...
 
 class AsyncBatchFlow(
-    AsyncFlow[Optional[List[Params]], Any, _PostResult],
-    BatchFlow[Optional[List[Params]], Any, _PostResult],
+    AsyncFlow[list[Params] | None, Any, _PostResult],
+    BatchFlow[list[Params] | None, Any, _PostResult],
 ):
     async def _run_async(self, shared: SharedData) -> _PostResult: ...
 
 class AsyncParallelBatchFlow(
-    AsyncFlow[Optional[List[Params]], Any, _PostResult],
-    BatchFlow[Optional[List[Params]], Any, _PostResult],
+    AsyncFlow[list[Params] | None, Any, _PostResult],
+    BatchFlow[list[Params] | None, Any, _PostResult],
 ):
     async def _run_async(self, shared: SharedData) -> _PostResult: ...
 
@@ -116,11 +117,11 @@ class LLMClient:
 
     def __init__(
         self,
-        provider: Optional[str] = None,
-        model: Optional[str] = None,
-        api_key: Optional[str] = None,
-        api_key_env: Optional[str] = None,
-        base_url: Optional[str] = None,
+        provider: str | None = None,
+        model: str | None = None,
+        api_key: str | None = None,
+        api_key_env: str | None = None,
+        base_url: str | None = None,
     ) -> None: ...
     def chat_complete(
         self,
@@ -131,10 +132,10 @@ class LLMClient:
     def ask(self, prompt: str, schema: Any = None, retries: int = 3) -> Any: ...
     def stream(self, prompt: str) -> Iterator[str]: ...
 
-class RAGNode(Node[str, List[str], str]):
+class RAGNode(Node[str, list[str], str]):
     def __init__(
         self,
-        sources: Union[str, List[str], None] = None,
+        sources: str | list[str] | None = None,
         query_key: str = "query",
         context_key: str = "rag_context",
         chunks_key: str = "rag_chunks",
@@ -143,11 +144,11 @@ class RAGNode(Node[str, List[str], str]):
         faiss: bool = False,
         embedding_provider: str = "local",
         embedding_model: str = "all-MiniLM-L6-v2",
-        embedding_api_key: Optional[str] = None,
+        embedding_api_key: str | None = None,
         chunk_mode: str = "smart",
-        persist_path: Optional[str] = None,
+        persist_path: str | None = None,
     ) -> None: ...
     def add_source(self, source: str) -> "RAGNode": ...
     def prep(self, shared: SharedData) -> str: ...
-    def exec(self, query: str) -> List[str]: ...
-    def post(self, shared: SharedData, query: str, chunks: List[str]) -> str: ...
+    def exec(self, query: str) -> list[str]: ...
+    def post(self, shared: SharedData, query: str, chunks: list[str]) -> str: ...

--- a/fenn/agents/tools.py
+++ b/fenn/agents/tools.py
@@ -1,8 +1,8 @@
 import inspect
 from functools import wraps
-from typing import Any, Dict
+from typing import Any
 
-TOOLS_REGISTRY: Dict[str, Dict[str, Any]] = {}
+TOOLS_REGISTRY: dict[str, dict[str, Any]] = {}
 
 
 def tool(func):

--- a/fenn/app.py
+++ b/fenn/app.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any
 
 from colorama import Fore, Style
 
@@ -40,7 +41,7 @@ class Fenn:
         # Please do not modify this class unless you know what you are doing.
         self._config_file: str = None
 
-        self._entrypoint_fn: Optional[Callable] = None
+        self._entrypoint_fn: Callable | None = None
 
         self._disable_disclaimer = False
 

--- a/fenn/dashboard/app.py
+++ b/fenn/dashboard/app.py
@@ -5,7 +5,6 @@ import logging
 import secrets
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional
 
 from flask import (
     Flask,
@@ -199,7 +198,7 @@ _MAX_LIMIT = 200
 _DEFAULT_LIMIT = 20
 
 
-def _api_error(code: str, message: str, param: Optional[str] = None):
+def _api_error(code: str, message: str, param: str | None = None):
     """Standard 400 envelope so clients can branch on `error.code`."""
     body = {"error": {"code": code, "message": message}}
     if param is not None:
@@ -208,7 +207,7 @@ def _api_error(code: str, message: str, param: Optional[str] = None):
 
 
 def _parse_int_arg(
-    name: str, raw: Optional[str], default: int, min_v: int, max_v: int
+    name: str, raw: str | None, default: int, min_v: int, max_v: int
 ) -> int:
     if raw is None or raw == "":
         return default
@@ -222,7 +221,7 @@ def _parse_int_arg(
 
 
 class _ApiBadRequest(Exception):
-    def __init__(self, message: str, param: Optional[str] = None):
+    def __init__(self, message: str, param: str | None = None):
         self.message = message
         self.param = param
 

--- a/fenn/dashboard/auth.py
+++ b/fenn/dashboard/auth.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import re
 from functools import wraps
-from typing import Optional
 
 import requests
 from flask import g, redirect, session, url_for
@@ -38,7 +37,7 @@ class AuthUnreachableError(Exception):
     """pyfenn.com could not be reached or returned an unexpected response."""
 
 
-def current_user() -> Optional[dict]:
+def current_user() -> dict | None:
     """Return the logged-in user dict, or ``None``. Cached on ``g``."""
     if "current_user" in g:
         return g.current_user

--- a/fenn/dashboard/scanner.py
+++ b/fenn/dashboard/scanner.py
@@ -3,7 +3,7 @@
 import os
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 from xml.etree import ElementTree
 
 # Default directories to scan (resolved at runtime)
@@ -46,17 +46,17 @@ def _running_timeout_s() -> float:
 class FennScanner:
     """Discovers and parses .fn log files from configured directories."""
 
-    def __init__(self, extra_dirs: Optional[List[str]] = None) -> None:
-        self._dirs: List[Path] = []
+    def __init__(self, extra_dirs: list[str] | None = None) -> None:
+        self._dirs: list[Path] = []
 
         # Parse-result cache keyed by file path. Stores (mtime, parsed_dict).
         # Entries are reused only when mtime matches, so any file write
         # (including in-progress logging) invalidates naturally.
-        self._parse_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+        self._parse_cache: dict[str, tuple[float, dict[str, Any]]] = {}
 
         # Directory-listing cache: (timestamp, files). Reused for up to
         # _FILES_CACHE_TTL_S to absorb bursty requests cheaply.
-        self._files_cache: Optional[Tuple[float, List[Path]]] = None
+        self._files_cache: tuple[float, list[Path]] | None = None
 
         # Load from environment variable
         env_dirs = os.environ.get("FENN_LOG_DIRS", "")
@@ -73,7 +73,7 @@ class FennScanner:
             for d in extra_dirs:
                 self._add_dir(d)
 
-    def add_dirs(self, dirs: List[str]) -> None:
+    def add_dirs(self, dirs: list[str]) -> None:
         for d in dirs:
             self._add_dir(d)
 
@@ -88,7 +88,7 @@ class FennScanner:
     # Public API
     # ------------------------------------------------------------------
 
-    def find_fn_files(self) -> List[Path]:
+    def find_fn_files(self) -> list[Path]:
         """Return all .fn files sorted by modification time (newest first)."""
         now = time.time()
         if self._files_cache is not None:
@@ -96,7 +96,7 @@ class FennScanner:
             if now - ts < _FILES_CACHE_TTL_S:
                 return cached
 
-        files: List[Path] = []
+        files: list[Path] = []
         for d in self._dirs:
             if d.exists() and d.is_dir():
                 files.extend(d.rglob("*.fn"))
@@ -110,7 +110,7 @@ class FennScanner:
         self._files_cache = (now, ordered)
         return ordered
 
-    def parse_fn_file(self, path: Path) -> Optional[Dict[str, Any]]:
+    def parse_fn_file(self, path: Path) -> dict[str, Any] | None:
         """Parse a single .fn file. Handles incomplete (running) sessions.
 
         Results are cached by ``(path, mtime)``; identical files are not
@@ -138,7 +138,7 @@ class FennScanner:
         return self._refresh_running_status(parsed, mtime)
 
     @staticmethod
-    def _parse_uncached(path: Path, stat: os.stat_result) -> Optional[Dict[str, Any]]:
+    def _parse_uncached(path: Path, stat: os.stat_result) -> dict[str, Any] | None:
         try:
             content = path.read_text(encoding="utf-8")
         except (OSError, PermissionError):
@@ -162,7 +162,7 @@ class FennScanner:
             status = meta.get("status", "completed")
 
         # Config
-        config: Dict[str, str] = {}
+        config: dict[str, str] = {}
         config_el = root.find("config")
         if config_el is not None:
             for item in config_el.findall("item"):
@@ -184,8 +184,8 @@ class FennScanner:
             )
 
         # Timing from <meta>
-        ended: Optional[str] = None
-        duration_s: Optional[int] = None
+        ended: str | None = None
+        duration_s: int | None = None
         if meta is not None:
             ended = meta.get("ended")
             try:
@@ -214,7 +214,7 @@ class FennScanner:
         }
 
     @staticmethod
-    def _refresh_running_status(parsed: Dict[str, Any], mtime: float) -> Dict[str, Any]:
+    def _refresh_running_status(parsed: dict[str, Any], mtime: float) -> dict[str, Any]:
         """Re-evaluate stale "running" sessions against the current timeout.
 
         Cached results are reused across requests, but the running→crashed
@@ -226,7 +226,7 @@ class FennScanner:
                 return {**parsed, "status": "crashed"}
         return parsed
 
-    def get_all_sessions(self) -> List[Dict[str, Any]]:
+    def get_all_sessions(self) -> list[dict[str, Any]]:
         """Return all parsed sessions, newest first."""
         sessions = []
         for path in self.find_fn_files():
@@ -236,9 +236,9 @@ class FennScanner:
         return sessions
 
     @staticmethod
-    def _build_projects_list(sessions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _build_projects_list(sessions: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Aggregate per-project stats from an already-loaded sessions list."""
-        projects: Dict[str, Dict[str, Any]] = {}
+        projects: dict[str, dict[str, Any]] = {}
         for s in sessions:
             name = s["project"]
             if name not in projects:
@@ -263,7 +263,7 @@ class FennScanner:
             projects.values(), key=lambda project: project["last_active"], reverse=True
         )
 
-    def get_overview(self) -> Dict[str, Any]:
+    def get_overview(self) -> dict[str, Any]:
         """Aggregate stats for the dashboard home page."""
         sessions = self.get_all_sessions()
         project_list = self._build_projects_list(sessions)
@@ -280,7 +280,7 @@ class FennScanner:
             "active_page": "home",
         }
 
-    def get_project(self, project_name: str) -> Dict[str, Any]:
+    def get_project(self, project_name: str) -> dict[str, Any]:
         """Return all sessions for a specific project."""
         all_sessions = self.get_all_sessions()
         sessions = [s for s in all_sessions if s["project"] == project_name]
@@ -298,9 +298,7 @@ class FennScanner:
             "active_project": project_name,
         }
 
-    def get_session(
-        self, project_name: str, session_id: str
-    ) -> Optional[Dict[str, Any]]:
+    def get_session(self, project_name: str, session_id: str) -> dict[str, Any] | None:
         """Return full data for a single session.
 
         Fenn writes ``<session_id>.fn`` so the filename stem matches the id;
@@ -331,12 +329,12 @@ class FennScanner:
 
     def list_sessions(
         self,
-        project: Optional[str] = None,
-        status: Optional[str] = None,
+        project: str | None = None,
+        status: str | None = None,
         limit: int = 20,
         offset: int = 0,
         sort: str = "-started",
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Return a filtered, sorted, paginated slice of sessions.
 
         ``sort`` is a field name optionally prefixed with ``-`` for descending
@@ -363,7 +361,7 @@ class FennScanner:
         # Sorts None values last (ascending) / first (descending) without comparing None to
         # non-None values, but may raise TypeError if non-None values are of different types
         # (e.g., int vs str).
-        def sort_key(s: Dict[str, Any]):
+        def sort_key(s: dict[str, Any]):
             v = s.get(field)
             return v is None, v
 
@@ -382,7 +380,7 @@ class FennScanner:
         }
 
     @staticmethod
-    def format_duration(seconds: Optional[int]) -> str:
+    def format_duration(seconds: int | None) -> str:
         if seconds is None:
             return "—"
         if seconds < 60:

--- a/fenn/dashboard/token_store.py
+++ b/fenn/dashboard/token_store.py
@@ -17,7 +17,7 @@ import json
 import os
 import stat
 from pathlib import Path
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 from fenn.logging import logger
 
@@ -41,7 +41,7 @@ def _is_valid(payload: object) -> bool:
     return isinstance(user.get("user_id"), str) and isinstance(user.get("email"), str)
 
 
-def load() -> Optional[StoredSession]:
+def load() -> StoredSession | None:
     """Return the stored session, or ``None`` if absent / unreadable."""
     try:
         raw = _PATH.read_text(encoding="utf-8")

--- a/fenn/experimental/vision/image_batch_check.py
+++ b/fenn/experimental/vision/image_batch_check.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, TypedDict
+from typing import Any, Literal, TypedDict
 from fenn.logging import logger
 
 import numpy as np
@@ -18,8 +18,8 @@ class BatchReport(TypedDict):
     """Structured report of batch validation results."""
 
     is_valid: bool  # True if no errors found
-    issues: List[BatchIssue]  # List of detected issues -> count
-    summary: Dict[str, Any]  # Summary statistics about the batch
+    issues: list[BatchIssue]  # List of detected issues -> count
+    summary: dict[str, Any]  # Summary statistics about the batch
 
 
 def check_image_batch(array) -> BatchReport:
@@ -46,7 +46,7 @@ def check_image_batch(array) -> BatchReport:
             - issues: List of detected issues with severity, category, and message
             - summary: Summary statistics (batch_size, shape, dtype, channels, etc.)
     """
-    issues: List[BatchIssue] = []
+    issues: list[BatchIssue] = []
     outlier_threshold = 5.0
     try:
         format_info = detect_format(array)

--- a/fenn/experimental/vision/image_dir_summary.py
+++ b/fenn/experimental/vision/image_dir_summary.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from pathlib import Path
-from typing import Any, Dict, List, TypedDict
+from typing import Any, TypedDict
 from fenn.logging import logger
 
 try:
@@ -17,22 +17,22 @@ class ImageDirSummary(TypedDict):
     """Summary information for a directory of images."""
 
     total_count: int
-    formats: Dict[str, int]  # Format extension -> count
-    resolutions: Dict[str, int]  # Resolution string like "1920x1080" -> count
-    color_modes: Dict[str, int]  # Color mode -> count (e.g., 'RGB', 'GRAY', 'RGBA')
-    examples: List[Dict[str, Any]]  # Sample file paths with metadata
-    failed_files: List[str]  # Paths of files that couldn't be read
+    formats: dict[str, int]  # Format extension -> count
+    resolutions: dict[str, int]  # Resolution string like "1920x1080" -> count
+    color_modes: dict[str, int]  # Color mode -> count (e.g., 'RGB', 'GRAY', 'RGBA')
+    examples: list[dict[str, Any]]  # Sample file paths with metadata
+    failed_files: list[str]  # Paths of files that couldn't be read
     failed_count: int  # Number of files that couldn't be read
 
 
 def _select_examples(
-    all_metadata: List[Dict[str, Any]],
+    all_metadata: list[dict[str, Any]],
     resolution_counter: Counter,
     format_counter: Counter,
     color_mode_counter: Counter,
     total_count: int,
     max_examples: int,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     Select representative examples that show diversity in resolutions, formats, and modes.
 

--- a/fenn/experimental/vision/resize.py
+++ b/fenn/experimental/vision/resize.py
@@ -1,5 +1,3 @@
-from typing import Tuple, Union
-
 import numpy as np
 
 try:
@@ -15,7 +13,7 @@ from .vision_utils import detect_format
 
 def resize_batch(
     array: np.ndarray,
-    size: Union[int, Tuple[int, int]],
+    size: int | tuple[int, int],
     interpolation: str = "bilinear",
 ) -> np.ndarray:
     """

--- a/fenn/experimental/vision/summary.py
+++ b/fenn/experimental/vision/summary.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 import numpy as np
 
@@ -7,7 +7,7 @@ from .vision_utils import detect_format
 
 def _extract_shape_info(
     shape: tuple, channel_location: Literal["first", "last"] | None
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Extract shape information (H, W, C) from array shape based on channel location.
 
@@ -48,11 +48,11 @@ class ImageSummary(TypedDict):
     is_grayscale: bool
     channel_location: Literal["first", "last"] | None
     batch_size: int
-    shape_info: Dict[str, Any]  # Contains: height, width, channels, full_shape
-    dtype: Dict[str, Any]  # Contains: name, kind, itemsize
-    value_range: Dict[str, Any]  # TODO: Define structure for value_range
-    channel_stats: Dict[str, Any]  # TODO: Define structure for channel_stats
-    data_quality: Dict[str, Any]  # TODO: Define structure for data_quality
+    shape_info: dict[str, Any]  # Contains: height, width, channels, full_shape
+    dtype: dict[str, Any]  # Contains: name, kind, itemsize
+    value_range: dict[str, Any]  # TODO: Define structure for value_range
+    channel_stats: dict[str, Any]  # TODO: Define structure for channel_stats
+    data_quality: dict[str, Any]  # TODO: Define structure for data_quality
 
 
 def image_summary(array: np.ndarray) -> ImageSummary:

--- a/fenn/exporter.py
+++ b/fenn/exporter.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 
 class Exporter:
@@ -19,7 +19,7 @@ class Exporter:
         self._export_dir = Path("export/fenn")
         self._initialized = True
 
-    def configure(self, args: Dict[str, Any]) -> Path:
+    def configure(self, args: dict[str, Any]) -> Path:
         """Configure the export directory from arguments."""
 
         export_conf = args.get("export", {}) or {}

--- a/fenn/nn/trainers/classification_trainer.py
+++ b/fenn/nn/trainers/classification_trainer.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Optional, Union, cast
+from typing import cast
 
 import torch
 import torch.nn
@@ -67,9 +67,9 @@ class ClassificationTrainer(Trainer):
         optim: torch.optim.Optimizer,
         num_classes: int,
         multi_label: bool = False,
-        device: Union[torch.device, str] = "cpu",
-        early_stopping_patience: Optional[int] = None,
-        checkpoint_config: Optional[Checkpoint] = None,
+        device: torch.device | str = "cpu",
+        early_stopping_patience: int | None = None,
+        checkpoint_config: Checkpoint | None = None,
     ):
         """Initialize a ClassificationTrainer instance.
 
@@ -118,7 +118,7 @@ class ClassificationTrainer(Trainer):
         self,
         train_loader: DataLoader,
         epochs: int,
-        val_loader: Optional[DataLoader] = None,
+        val_loader: DataLoader | None = None,
         val_epochs: int = 1,
     ):
         """Train the model with optional validation and early stopping.
@@ -313,7 +313,7 @@ class ClassificationTrainer(Trainer):
 
     def predict(
         self,
-        dataloader_or_batch: Union[DataLoader, torch.Tensor],
+        dataloader_or_batch: DataLoader | torch.Tensor,
         return_proba: bool = False,
     ):
         """Predicts the output of the model for a given dataloader or batch.

--- a/fenn/nn/trainers/lora_trainer.py
+++ b/fenn/nn/trainers/lora_trainer.py
@@ -1,6 +1,6 @@
 import inspect
 from copy import deepcopy
-from typing import Dict, List, Optional, Union, cast
+from typing import cast
 
 import torch
 import torch.nn
@@ -58,12 +58,12 @@ class LoRATrainer(Trainer):
         r: int = 8,
         lora_alpha: int = 16,
         lora_dropout: float = 0.1,
-        target_modules: Optional[List[str]] = None,
+        target_modules: list[str] | None = None,
         bias: str = "none",
-        loss_fn: Optional[torch.nn.Module] = None,
-        device: Union[torch.device, str] = "cpu",
-        early_stopping_patience: Optional[int] = None,
-        checkpoint_config: Optional[Checkpoint] = None,
+        loss_fn: torch.nn.Module | None = None,
+        device: torch.device | str = "cpu",
+        early_stopping_patience: int | None = None,
+        checkpoint_config: Checkpoint | None = None,
     ):
         """Initialize the LoRATrainer.
 
@@ -147,9 +147,7 @@ class LoRATrainer(Trainer):
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _forward(
-        self, batch: Dict
-    ) -> tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    def _forward(self, batch: dict) -> tuple[torch.Tensor | None, torch.Tensor | None]:
         """Run one forward pass.
 
         Returns:
@@ -157,8 +155,8 @@ class LoRATrainer(Trainer):
             does not produce them.
         """
         outputs = self._model(**batch)
-        loss: Optional[torch.Tensor] = getattr(outputs, "loss", None)
-        logits: Optional[torch.Tensor] = getattr(outputs, "logits", None)
+        loss: torch.Tensor | None = getattr(outputs, "loss", None)
+        logits: torch.Tensor | None = getattr(outputs, "logits", None)
 
         if loss is None and self._loss_fn is not None and logits is not None:
             labels = batch.get("labels")
@@ -175,7 +173,7 @@ class LoRATrainer(Trainer):
         self,
         train_loader: DataLoader,
         epochs: int,
-        val_loader: Optional[DataLoader] = None,
+        val_loader: DataLoader | None = None,
         val_epochs: int = 1,
     ):
         """Train the model with optional validation and early stopping.
@@ -363,7 +361,7 @@ class LoRATrainer(Trainer):
 
         progress.stop()
 
-    def predict(self, dataloader_or_batch: Union[DataLoader, Dict, torch.Tensor]):
+    def predict(self, dataloader_or_batch: DataLoader | dict | torch.Tensor):
         """Generate predictions for a dataloader or a single batch.
 
         Labels are stripped from dict batches before inference so the model

--- a/fenn/nn/trainers/regression_trainer.py
+++ b/fenn/nn/trainers/regression_trainer.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Optional, Union, cast
+from typing import cast
 
 import torch
 import torch.nn
@@ -47,9 +47,9 @@ class RegressionTrainer(Trainer):
         loss_fn: torch.nn.Module,
         optim: torch.optim.Optimizer,
         return_model: str = "last",
-        device: Union[torch.device, str] = "cpu",
-        early_stopping_patience: Optional[int] = None,
-        checkpoint_config: Optional[Checkpoint] = None,
+        device: torch.device | str = "cpu",
+        early_stopping_patience: int | None = None,
+        checkpoint_config: Checkpoint | None = None,
     ):
         """Initialize a RegressionTrainer instance.
 
@@ -80,7 +80,7 @@ class RegressionTrainer(Trainer):
         self,
         train_loader: DataLoader,
         epochs: int,
-        val_loader: Optional[DataLoader] = None,
+        val_loader: DataLoader | None = None,
         val_epochs: int = 1,
     ):
         """Train the model with optional validation and early stopping.
@@ -274,7 +274,7 @@ class RegressionTrainer(Trainer):
 
         return self._model
 
-    def predict(self, dataloader_or_batch: Union[DataLoader, torch.Tensor]):
+    def predict(self, dataloader_or_batch: DataLoader | torch.Tensor):
         """Predicts the output of the model for a given dataloader or batch.
 
         Args:

--- a/fenn/nn/trainers/trainer.py
+++ b/fenn/nn/trainers/trainer.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
 import torch
 import torch.nn
@@ -38,9 +38,9 @@ class Trainer(ABC):
         model: torch.nn.Module,
         loss_fn: torch.nn.Module,
         optim: torch.optim.Optimizer,
-        device: Union[torch.device, str] = "cpu",
-        early_stopping_patience: Optional[int] = None,
-        checkpoint_config: Optional[Checkpoint] = None,
+        device: torch.device | str = "cpu",
+        early_stopping_patience: int | None = None,
+        checkpoint_config: Checkpoint | None = None,
     ):
         """Initialize a Trainer instance to fit a neural network model.
 
@@ -66,10 +66,10 @@ class Trainer(ABC):
         self._state = TrainingState(epoch=0)
         self._log_model_summary()
 
-        self._best_state: Optional[TrainingState] = None
+        self._best_state: TrainingState | None = None
         """Best training state based on validation loss."""
 
-        self._best_model: Optional[torch.nn.Module] = None
+        self._best_model: torch.nn.Module | None = None
 
         # checkpoint setup
         self._checkpoint = checkpoint_config
@@ -87,7 +87,7 @@ class Trainer(ABC):
         summary = ModelPrettyPrinter(self._model).render()
         logger.info(summary, extra={"skip_console": True})
 
-    def _move_to_device(self, batch: Any, device: Union[torch.device, str]) -> Any:
+    def _move_to_device(self, batch: Any, device: torch.device | str) -> Any:
         """Recursively move tensor data to the specified device.
 
         Handles tensors, lists, tuples, and dictionaries of tensors.
@@ -145,7 +145,7 @@ class Trainer(ABC):
         self,
         train_loader: DataLoader,
         epochs: int,
-        val_loader: Optional[DataLoader] = None,
+        val_loader: DataLoader | None = None,
         val_epochs: int = 1,
     ):
         """Train the model for a fixed number of epochs.
@@ -193,7 +193,7 @@ class Trainer(ABC):
         if new_state.optimizer_state_dict:
             self._optimizer.load_state_dict(new_state.optimizer_state_dict)
 
-    def load_checkpoint(self, checkpoint_path: Union[str, Path]) -> None:
+    def load_checkpoint(self, checkpoint_path: str | Path) -> None:
         """Load a checkpoint from the given file path and restore training state.
 
         Restores the model weights, optimizer state, and epoch counter from
@@ -251,7 +251,7 @@ class Trainer(ABC):
         torch.save(self._model.state_dict(), (self._exporter.export_dir / model_name))
 
     @abstractmethod
-    def predict(self, dataloader_or_batch: Union[DataLoader, torch.Tensor]):
+    def predict(self, dataloader_or_batch: DataLoader | torch.Tensor):
         """Generate predictions from the trained model.
 
         Runs inference on the provided data without computing gradients,

--- a/fenn/nn/utils/checkpoint.py
+++ b/fenn/nn/utils/checkpoint.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional
 
 import torch
 
@@ -32,8 +32,8 @@ class Checkpoint:
         self,
         *,
         name: str = "checkpoint",
-        dir: Union[Path, str],
-        epochs: Optional[Union[int, List[int]]] = None,
+        dir: Path | str,
+        epochs: int | list[int] | None = None,
         save_best: bool = True,
     ):
         """Initialize the checkpoint configuration.
@@ -102,7 +102,7 @@ class Checkpoint:
             )
 
     def load(
-        self, checkpoint_path: Union[str, Path], device: Optional[torch.device] = None
+        self, checkpoint_path: str | Path, device: torch.device | None = None
     ) -> TrainingState:
         """Load a checkpoint from the given path.
 
@@ -132,7 +132,7 @@ class Checkpoint:
         return state
 
     def load_at_epoch(
-        self, epoch: int, device: Optional[torch.device] = None
+        self, epoch: int, device: torch.device | None = None
     ) -> TrainingState:
         """Load the checkpoint at the given epoch.
 
@@ -152,7 +152,7 @@ class Checkpoint:
             )
         return self.load(filepath, device)
 
-    def load_best(self, device: Optional[torch.device] = None) -> TrainingState:
+    def load_best(self, device: torch.device | None = None) -> TrainingState:
         """Load the best checkpoint.
 
         Args:

--- a/fenn/nn/utils/model_pretty_printer.py
+++ b/fenn/nn/utils/model_pretty_printer.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 import torch.nn as nn
 
 
 @dataclass(frozen=True)
 class _RenderLimits:
-    max_depth: Optional[int]
-    max_children: Optional[int]
-    max_lines: Optional[int]
+    max_depth: int | None
+    max_children: int | None
+    max_lines: int | None
 
 
 class ModelPrettyPrinter:

--- a/fenn/nn/utils/state.py
+++ b/fenn/nn/utils/state.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass, replace
-from typing import Any, Optional, TypeAlias
+from typing import Any, TypeAlias
 
 StateDict: TypeAlias = dict[str, Any]
 
@@ -12,17 +12,17 @@ class TrainingState:
 
     epoch: int
 
-    acc: Optional[float] = None
+    acc: float | None = None
     """Accuracy on the validation set (if provided)"""
 
-    train_loss: Optional[float] = None
+    train_loss: float | None = None
     """Train mean loss over all batches"""
 
-    val_loss: Optional[float] = None
+    val_loss: float | None = None
     """Validation mean loss over all batches"""
 
-    model_state_dict: Optional[StateDict] = None
-    optimizer_state_dict: Optional[StateDict] = None
+    model_state_dict: StateDict | None = None
+    optimizer_state_dict: StateDict | None = None
 
     patience_counter: int = 0
     """Patience counter up to this epoch for early stopping."""

--- a/fenn/notification/notifier.py
+++ b/fenn/notification/notifier.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Type
+from typing import Iterable
 
 from .service import Service
 
@@ -8,11 +8,11 @@ class Notifier:
 
     def __init__(self):
         """Initialize the notifier with an empty list of services."""
-        self._services: List[Service] = []
+        self._services: list[Service] = []
 
     def add_services(
         self,
-        services: Iterable[Type[Service]],
+        services: Iterable[type[Service]],
     ) -> None:
         """
         Add a list of notification services.
@@ -24,7 +24,7 @@ class Notifier:
         for service_cls in services:
             self.add_service(service_cls)
 
-    def add_service(self, service: Type[Service]) -> None:
+    def add_service(self, service: type[Service]) -> None:
         """Add a notification service.
 
         Args:
@@ -32,7 +32,7 @@ class Notifier:
         """
         self._services.append(service())
 
-    def remove_service(self, service: Type[Service]) -> None:
+    def remove_service(self, service: type[Service]) -> None:
         """Remove a notification service.
 
         Args:
@@ -70,7 +70,7 @@ class Notifier:
                 failed_services.append((service.__class__.__name__, str(e)))
                 # logger.error(f"Failed to send notification via {service.__class__.__name__}: {e}")
 
-    def get_services(self) -> List[str]:
+    def get_services(self) -> list[str]:
         """Get list of registered service names.
 
         Returns:

--- a/fenn/parser.py
+++ b/fenn/parser.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import yaml
 from colorama import init
@@ -21,7 +21,7 @@ class Parser:
             return
 
         self._config_file: Path = Path(config_file)
-        self._args: Dict[str, Any] = {}
+        self._args: dict[str, Any] = {}
 
         self._keystore: KeyStore = KeyStore()
 
@@ -64,5 +64,5 @@ class Parser:
         self._config_file: Path = Path(config_file)
 
     @property
-    def args(self) -> Dict[str, Any]:
+    def args(self) -> dict[str, Any]:
         return self._args


### PR DESCRIPTION
- Closes #195 

Updates typing to use up-to-date best practices, including (and LIMITED to):

- Use `Iterator`, `Callable`, `Sequence` from `collections.abc` instead of `typing`:
```python
from collections.abc import Iterator, Callable, Sequence

# instead of
from typing import Iterator, Callable, Sequence
```
- Use `list`, `dict`, `tuple` instead of `List`, `Dict`, `Tuple` from `typing`:
```python
TOOLS_REGISTRY: dict[str, dict[str, Any]] = {}

# instead of
from typing import List, Dict, Tuple
TOOLS_REGISTRY: Dict[str, Dict[str, Any]] = {}
```
- Use `|` operator to replace `typing.Union` and `typing.Optional`:
```python
wait: int | float = 0
items: list[_PrepResult] | None

# instead of
from typing import Optional, Union
wait: Union[int, float] = 0
items: Optional[List[_PrepResult]]
```

Changes applied to whole `fenn/` (searched `tests/`, no matches found)