### PR TITLE
fix: add TextDataset type annotations

### DIFF
--- a/fenn/datasets/text_dataset.py
+++ b/fenn/datasets/text_dataset.py
@@ -1,10 +1,27 @@
-from typing import Optional, Sequence, Union
+from collections.abc import Mapping, Sequence
+from typing import Protocol, TypeAlias
 
 import torch
+from torch import Tensor
 from torch.utils.data import Dataset
 
+LabelValue: TypeAlias = int | float
+TextDatasetItem: TypeAlias = tuple[Tensor, Tensor] | tuple[Tensor, Tensor, Tensor]
 
-class TextDataset(Dataset):
+
+class TextTokenizer(Protocol):
+    def __call__(
+        self,
+        text: str,
+        *,
+        truncation: bool,
+        padding: str,
+        max_length: int,
+        return_tensors: str,
+    ) -> Mapping[str, Tensor]: ...
+
+
+class TextDataset(Dataset[TextDatasetItem]):
     """
     Generic text + binary label dataset.
     X: list[str]
@@ -14,29 +31,29 @@ class TextDataset(Dataset):
     def __init__(
         self,
         X: Sequence[str],
-        y: Optional[Sequence[Union[int, float]]],
-        tokenizer,
+        y: Sequence[LabelValue] | None,
+        tokenizer: TextTokenizer,
         max_length: int = 1024,
-    ):
-        self.X = list(X)
-        self.y = None if y is None else [float(v) for v in y]
-        self.tokenizer = tokenizer
-        self.max_length = max_length
+    ) -> None:
+        self.X: list[str] = list(X)
+        self.y: list[float] | None = None if y is None else [float(v) for v in y]
+        self.tokenizer: TextTokenizer = tokenizer
+        self.max_length: int = max_length
 
     def __len__(self) -> int:
         return len(self.X)
 
-    def __getitem__(self, idx: int):
-        enc = self.tokenizer(
-            self.X[idx],
+    def __getitem__(self, index: int) -> TextDatasetItem:
+        enc: Mapping[str, Tensor] = self.tokenizer(
+            self.X[index],
             truncation=True,
             padding="max_length",
             max_length=self.max_length,
             return_tensors="pt",
         )
-        input_ids = enc["input_ids"].squeeze(0)
-        attention_mask = enc["attention_mask"].squeeze(0)
+        input_ids: Tensor = enc["input_ids"].squeeze(0)
+        attention_mask: Tensor = enc["attention_mask"].squeeze(0)
         if self.y is None:
             return input_ids, attention_mask
-        label = torch.tensor(self.y[idx], dtype=torch.float32)
+        label: Tensor = torch.tensor(self.y[index], dtype=torch.float32)
         return input_ids, attention_mask, label


### PR DESCRIPTION
## Summary
- Add concrete type aliases for TextDataset labels and returned items.
- Type the tokenizer callable, stored attributes, and dataset item return path.

## Testing
- [x] `python - <<'PY' ... PY`
- [x] `ruff check fenn/datasets/text_dataset.py`
- [x] `ruff format --check fenn/datasets/text_dataset.py`
- [x] `ty check fenn/datasets/text_dataset.py`
- [x] `pre-commit run --files fenn/datasets/text_dataset.py`
- [x] `git diff --check`

Closes #189
