### PR TITLE
Add typing to dashboard app

### DIFF
--- a/fenn/dashboard/app.py
+++ b/fenn/dashboard/app.py
@@ -1,5 +1,7 @@
 """Fenn Dashboard — Flask application for browsing fnxml log files."""
 
+from __future__ import annotations
+
 import argparse
 import logging
 import secrets
@@ -8,6 +10,7 @@ from pathlib import Path
 
 from flask import (
     Flask,
+    Response,
     abort,
     g,
     jsonify,
@@ -17,6 +20,7 @@ from flask import (
     session,
     url_for,
 )
+from flask.typing import ResponseReturnValue
 from flask_wtf.csrf import CSRFError, CSRFProtect
 
 from fenn.logging import logger
@@ -26,9 +30,11 @@ try:
     from fenn.dashboard import token_store
     from fenn.dashboard.scanner import FennScanner
 except ImportError:  # standalone: python app.py
-    import auth as dashboard_auth  # type: ignore[no-redef]
-    import token_store  # type: ignore[no-redef]
-    from scanner import FennScanner  # type: ignore[no-redef]
+    import auth as dashboard_auth  # type: ignore[no-redef]  # ty: ignore[unresolved-import]
+    import token_store  # type: ignore[no-redef]  # ty: ignore[unresolved-import]
+    from scanner import (  # ty: ignore[unresolved-import]
+        FennScanner,  # type: ignore[no-redef]
+    )
 
 _HERE = Path(__file__).parent
 
@@ -58,7 +64,7 @@ scanner = FennScanner()
 
 
 @app.context_processor
-def _inject_current_user():
+def _inject_current_user() -> dict[str, object]:
     return {"current_user": dashboard_auth.current_user()}
 
 
@@ -74,7 +80,7 @@ _STORED_TOKEN_OFFLINE_MESSAGE = (
 )
 
 
-def _try_stored_session():
+def _try_stored_session() -> ResponseReturnValue | None:
     """Re-establish a Flask session from ``~/.fenn/dashboard_session.json``.
 
     Returns ``None`` if the caller should proceed normally, or a Flask
@@ -112,7 +118,7 @@ def _try_stored_session():
 
 
 @app.before_request
-def _require_login():
+def _require_login() -> ResponseReturnValue | None:
     endpoint = request.endpoint
     if endpoint in _PUBLIC_ENDPOINTS:
         return None
@@ -127,7 +133,7 @@ def _require_login():
 
 
 @app.errorhandler(CSRFError)
-def _csrf_failed(_e):
+def _csrf_failed(_e: CSRFError) -> ResponseReturnValue:
     return render_template(
         "connect.html",
         error_message="Form expired. Please try again.",
@@ -141,12 +147,12 @@ def _csrf_failed(_e):
 
 
 @app.template_filter("duration")
-def duration_filter(seconds):
+def duration_filter(seconds: int | None) -> str:
     return scanner.format_duration(seconds)
 
 
 @app.template_filter("filesize")
-def filesize_filter(size):
+def filesize_filter(size: int) -> str:
     return scanner.format_size(size)
 
 
@@ -161,17 +167,17 @@ def short_id_filter(session_id: str) -> str:
 
 
 @app.route("/")
-def index():
+def index() -> str:
     return render_template("index.html", **scanner.get_overview())
 
 
 @app.route("/project/<project_name>")
-def project(project_name: str):
+def project(project_name: str) -> str:
     return render_template("project.html", **scanner.get_project(project_name))
 
 
 @app.route("/session/<project_name>/<session_id>", endpoint="session")
-def session_view(project_name: str, session_id: str):
+def session_view(project_name: str, session_id: str) -> str:
     data = scanner.get_session(project_name, session_id)
     if data is None:
         abort(404)
@@ -179,12 +185,12 @@ def session_view(project_name: str, session_id: str):
 
 
 @app.route("/api/overview")
-def api_overview():
+def api_overview() -> Response:
     return jsonify(scanner.get_overview())
 
 
 @app.route("/api/session/<project_name>/<session_id>")
-def api_session(project_name: str, session_id: str):
+def api_session(project_name: str, session_id: str) -> Response:
     data = scanner.get_session(project_name, session_id)
     if data is None:
         abort(404)
@@ -198,9 +204,11 @@ _MAX_LIMIT = 200
 _DEFAULT_LIMIT = 20
 
 
-def _api_error(code: str, message: str, param: str | None = None):
+def _api_error(
+    code: str, message: str, param: str | None = None
+) -> tuple[Response, int]:
     """Standard 400 envelope so clients can branch on `error.code`."""
-    body = {"error": {"code": code, "message": message}}
+    body: dict[str, dict[str, str]] = {"error": {"code": code, "message": message}}
     if param is not None:
         body["error"]["param"] = param
     return jsonify(body), 400
@@ -221,13 +229,13 @@ def _parse_int_arg(
 
 
 class _ApiBadRequest(Exception):
-    def __init__(self, message: str, param: str | None = None):
+    def __init__(self, message: str, param: str | None = None) -> None:
         self.message = message
         self.param = param
 
 
 @app.route("/api/sessions")
-def api_sessions():
+def api_sessions() -> ResponseReturnValue:
     """Filtered, sorted, paginated session listing.
 
     Query params: project, status, limit (1..200, default 20), offset (>=0,
@@ -263,7 +271,7 @@ def api_sessions():
 
 
 @app.errorhandler(404)
-def not_found(_e):
+def not_found(_e: object) -> tuple[str, int]:
     return render_template("404.html", **scanner.get_overview()), 404
 
 
@@ -279,7 +287,7 @@ _INVALID_TOKEN_MESSAGE = "Invalid or expired token."
 
 
 @app.route("/connect", methods=["GET", "POST"])
-def connect():
+def connect() -> ResponseReturnValue:
     # Already signed in → bounce to home.
     if dashboard_auth.current_user() is not None:
         return redirect(url_for("index"))
@@ -320,7 +328,7 @@ def connect():
 
 
 @app.route("/logout", methods=["POST"])
-def logout():
+def logout() -> ResponseReturnValue:
     session.clear()
     # Also drop the disk cache — otherwise the next request would
     # silently re-establish the same session via _try_stored_session().
@@ -334,7 +342,10 @@ def logout():
 
 
 def run(
-    host: str = "127.0.0.1", port: int = 5000, debug: bool = False, log_dirs=None
+    host: str = "127.0.0.1",
+    port: int = 5000,
+    debug: bool = False,
+    log_dirs: list[str] | None = None,
 ) -> None:
     """Configure and start the dashboard server."""
     if log_dirs:
@@ -353,7 +364,7 @@ def run(
 # --------------------------------------------------------------------------- #
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         prog="fenn-dashboard",
         description="Fenn Dashboard — browse fnxml log files in your browser",


### PR DESCRIPTION
## Summary
- add type annotations across the Flask dashboard app helpers, routes, filters, and CLI entry point
- use Flask's `ResponseReturnValue` for route-like functions that can return redirects, rendered templates, or response tuples
- keep the standalone `python app.py` fallback imports type-checker friendly

Closes #198

## Tests
- `.\.venv\Scripts\ruff.exe check fenn`
- `.\.venv\Scripts\ruff.exe format --check fenn\dashboard\app.py`
- `.\.venv\Scripts\ty.exe check fenn\dashboard\app.py`
- `.\.venv\Scripts\python.exe -m compileall fenn\dashboard\app.py`
- `.\.venv\Scripts\python.exe -m pytest tests\unit\dashboard -q`