### PR TITLE
[Dashboard]: Add Date Range Filtering for Session Listings APIs

### DIFF
--- a/fenn/dashboard/app.py
+++ b/fenn/dashboard/app.py
@@ -3,7 +3,7 @@
 import argparse
 import logging
 import secrets
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from flask import (
@@ -230,8 +230,13 @@ class _ApiBadRequest(Exception):
 def api_sessions():
     """Filtered, sorted, paginated session listing.
 
-    Query params: project, status, limit (1..200, default 20), offset (>=0,
-    default 0), sort (field, optionally ``-`` prefixed for descending).
+    Query params:
+        project,
+        status,
+        limit (1..200, default 20),
+        offset (>=0, default 0),
+        sort (field, optionally ``-`` prefixed for descending),
+        started_after, started_before (timestamps formatted as ``YYYY-MM-DD HH:MM:SS``).
     """
     try:
         project_name = request.args.get("project") or None
@@ -242,10 +247,38 @@ def api_sessions():
         )
         offset = _parse_int_arg("offset", request.args.get("offset"), 0, 0, 1_000_000)
 
+        started_after = None
+        started_after_raw = request.args.get("started_after") or None
+        if started_after_raw is not None:
+            try:
+                started_after = datetime.strptime(
+                    started_after_raw, "%Y-%m-%d %H:%M:%S"
+                )
+            except ValueError:
+                raise _ApiBadRequest(
+                    "started_after must be formatted as YYYY-MM-DD HH:MM:SS",
+                    "started_after",
+                )
+
+        started_before = None
+        started_before_raw = request.args.get("started_before") or None
+        if started_before_raw is not None:
+            try:
+                started_before = datetime.strptime(
+                    started_before_raw, "%Y-%m-%d %H:%M:%S"
+                )
+            except ValueError:
+                raise _ApiBadRequest(
+                    "started_before must be formatted as YYYY-MM-DD HH:MM:SS",
+                    "started_before",
+                )
+
         try:
             result = scanner.list_sessions(
                 project=project_name,
                 status=status,
+                started_after=started_after,
+                started_before=started_before,
                 limit=limit,
                 offset=offset,
                 sort=sort,

--- a/fenn/dashboard/scanner.py
+++ b/fenn/dashboard/scanner.py
@@ -2,8 +2,9 @@
 
 import os
 import time
+from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 from xml.etree import ElementTree
 
 # Default directories to scan (resolved at runtime)
@@ -331,6 +332,8 @@ class FennScanner:
         self,
         project: str | None = None,
         status: str | None = None,
+        started_after: Optional[datetime] = None,
+        started_before: Optional[datetime] = None,
         limit: int = 20,
         offset: int = 0,
         sort: str = "-started",
@@ -340,6 +343,11 @@ class FennScanner:
         ``sort`` is a field name optionally prefixed with ``-`` for descending
         order. Valid fields: started, ended, duration_s, warning_count,
         exception_count. Status must be one of running/crashed/completed/failed.
+
+        ``started_after`` and ``started_before`` filter by parsed ``started``
+        timestamp (inclusive). Sessions with missing or invalid ``started`` values
+        are skipped when either filter is used. If ``started_after`` is later than
+        ``started_before``, an empty result is returned.
 
         Raises ``ValueError`` on invalid status or sort field; callers are
         responsible for converting these into HTTP-shaped errors.
@@ -357,6 +365,29 @@ class FennScanner:
             sessions = [s for s in sessions if s["project"] == project]
         if status:
             sessions = [s for s in sessions if s["status"] == status]
+        if started_after is not None or started_before is not None:
+            if (
+                started_after is not None
+                and started_before is not None
+                and started_after > started_before
+            ):
+                sessions = []
+            else:
+                filtered = []
+                for s in sessions:
+                    raw = s.get("started")
+                    if not raw:
+                        continue
+                    try:
+                        started = datetime.strptime(raw, "%Y-%m-%d %H:%M:%S")
+                    except (ValueError, TypeError):
+                        continue
+                    if started_after is not None and started < started_after:
+                        continue
+                    if started_before is not None and started > started_before:
+                        continue
+                    filtered.append(s)
+                sessions = filtered
 
         # Sorts None values last (ascending) / first (descending) without comparing None to
         # non-None values, but may raise TypeError if non-None values are of different types

--- a/tests/unit/dashboard/test_api.py
+++ b/tests/unit/dashboard/test_api.py
@@ -275,3 +275,141 @@ class TestExistingEndpoints:
         data = resp.get_json()
         assert "projects" in data
         assert "total_sessions" in data
+
+
+# ---------------------------------------------------------------------------
+# Date range filtering
+# ---------------------------------------------------------------------------
+
+
+class TestApiSessionsDateRangeFilter:
+    """started_after= and started_before= query parameters must filter by
+    the session's started timestamp."""
+
+    def test_started_after_filters_out_earlier_sessions(self, client):
+        """?started_after should exclude sessions that started before it."""
+        resp = client.get("/api/sessions?started_after=2026-05-21 07:00:00")
+        data = resp.get_json()
+        sids = {s["session_id"] for s in data["items"]}
+        assert sids == {"a1", "a2"}
+        assert data["total"] == 2
+
+    def test_started_before_filters_out_later_sessions(self, client):
+        """?started_before should exclude sessions that started after it."""
+        resp = client.get("/api/sessions?started_before=2026-05-21 07:00:00")
+        data = resp.get_json()
+        sids = {s["session_id"] for s in data["items"]}
+        assert sids == {"a1", "b1"}
+        assert data["total"] == 2
+
+    def test_started_before_is_inclusive(self, client):
+        """A session started exactly at started_before must be included."""
+        resp = client.get("/api/sessions?started_before=2026-05-21 07:00:00")
+        data = resp.get_json()
+        sids = {s["session_id"] for s in data["items"]}
+        assert "a1" in sids
+
+    def test_combined_after_and_before_range(self, client):
+        """Both bounds together must return only sessions inside the range."""
+        resp = client.get(
+            "/api/sessions"
+            "?started_after=2026-05-21 06:30:00"
+            "&started_before=2026-05-21 07:30:00"
+        )
+        data = resp.get_json()
+        sids = {s["session_id"] for s in data["items"]}
+        assert sids == {"a1"}
+        assert data["total"] == 1
+
+    def test_inverted_range_returns_empty_without_error(self, client):
+        """started_after later than started_before must yield an empty
+        result set, not a 400."""
+        resp = client.get(
+            "/api/sessions"
+            "?started_after=2026-05-21 08:00:00"
+            "&started_before=2026-05-21 06:00:00"
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["items"] == []
+        assert data["total"] == 0
+
+    def test_date_filter_combined_with_project_and_status(self, client):
+        """Date range must AND together with existing project/status filters."""
+        resp = client.get(
+            "/api/sessions"
+            "?project=alpha&status=completed"
+            "&started_after=2026-05-21 00:00:00"
+        )
+        data = resp.get_json()
+        assert data["total"] == 1
+        assert data["items"][0]["session_id"] == "a1"
+
+    def test_no_date_filters_returns_all_sessions(self, client):
+        """Omitting both date params must not affect results (backward
+        compatibility)."""
+        resp = client.get("/api/sessions")
+        data = resp.get_json()
+        assert data["total"] == 3
+
+    def test_invalid_started_after_format_returns_400(self, client):
+        """Malformed started_after must return 400 with param='started_after'."""
+        resp = client.get("/api/sessions?started_after=2026-05-21")
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["error"]["code"] == "invalid_param"
+        assert body["error"]["param"] == "started_after"
+
+    def test_invalid_started_before_format_returns_400(self, client):
+        """Malformed started_before must return 400 with param='started_before'."""
+        resp = client.get("/api/sessions?started_before=not-a-date")
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["error"]["code"] == "invalid_param"
+        assert body["error"]["param"] == "started_before"
+
+    def test_session_with_unparsable_started_is_skipped(self, tmp_path):
+        """A session whose 'started' field can't be parsed must be skipped
+        when a date filter is active, not raise an error."""
+        sessions_dir = tmp_path
+        _write(
+            sessions_dir / "bad.fn",
+            _FN_TMPL.format(
+                project="alpha",
+                sid="bad1",
+                started="not-a-real-timestamp",
+                ended="2026-05-21 07:00:10",
+                dur=10,
+                status="completed",
+            ),
+        )
+        _write(
+            sessions_dir / "good.fn",
+            _FN_TMPL.format(
+                project="alpha",
+                sid="good1",
+                started="2026-05-21 07:00:00",
+                ended="2026-05-21 07:00:10",
+                dur=10,
+                status="completed",
+            ),
+        )
+        scanner = FennScanner(extra_dirs=[str(sessions_dir)])
+
+        import fenn.dashboard.app as app_module
+
+        original = app_module.scanner
+        app_module.scanner = scanner
+        app.config["TESTING"] = True
+        try:
+            with app.test_client() as c:
+                with c.session_transaction() as sess:
+                    sess["user"] = {"email": "test@example.com"}
+                resp = c.get("/api/sessions?started_after=2026-05-21 00:00:00")
+                assert resp.status_code == 200
+                data = resp.get_json()
+                sids = {s["session_id"] for s in data["items"]}
+                assert "bad1" not in sids
+                assert "good1" in sids
+        finally:
+            app_module.scanner = original


### PR DESCRIPTION
Fixes #182 

## Changes:

- Added `started_after` and `started_before` query parameters.
- Validated timestamp format using the existing `invalid_param` response pattern.
- Extended `FennScanner.list_sessions()` to support date range filtering.
- Applied filtering before sorting and pagination.
- Preserved existing behavior when no date filters are provided.
- Added tests covering valid and invalid date filter scenarios.