### PR TITLE
chore: [210] add RAG typings

### DIFF
--- a/fenn/agents/rag/rag.py
+++ b/fenn/agents/rag/rag.py
@@ -1,3 +1,7 @@
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
 from fenn.agents.llm import LLMClient
 from fenn.logging import logger
 
@@ -95,22 +99,22 @@ class RAG:
     def __init__(
         self,
         # ── LLM ───────────────────────────────────────────
-        model_provider=None,
-        model=None,
-        model_api_key=None,
-        base_url=None,
+        model_provider: str | None = None,
+        model: str | None = None,
+        model_api_key: str | None = None,
+        base_url: str | None = None,
         # ── Embeddings ────────────────────────────────────
-        faiss=False,
-        embedding_provider="local",
-        embedding_model="all-MiniLM-L6-v2",
-        embedding_api_key=None,
+        faiss: bool = False,
+        embedding_provider: str = "local",
+        embedding_model: str = "all-MiniLM-L6-v2",
+        embedding_api_key: str | None = None,
         # ── RAG behaviour ─────────────────────────────────
-        chunk_mode="smart",
-        persist_path=None,
-        memory=False,
-        max_history=None,
-        system_prompt=None,
-    ):
+        chunk_mode: str = "smart",
+        persist_path: str | Path | None = None,
+        memory: bool = False,
+        max_history: int | None = None,
+        system_prompt: str | None = None,
+    ) -> None:
         self._llm = LLMClient(
             provider=model_provider,
             model=model,
@@ -142,7 +146,7 @@ class RAG:
             "Be concise, accurate, and respond in the same language as the user's question."
         )
 
-    def add_source(self, source):
+    def add_source(self, source: str | Path) -> "RAG":
         """
         Load and index a document source.
 
@@ -167,7 +171,7 @@ class RAG:
         self._retriever.index(docs)
         return self
 
-    def add_tool(self, fn):
+    def add_tool(self, fn: Callable[..., Any]) -> "RAG":
         """
         Attach a custom Python function as a tool.
 
@@ -186,7 +190,7 @@ class RAG:
         self._tools.append(fn)
         return self
 
-    def debug(self):
+    def debug(self) -> "RAG":
         """
         Enable verbose logging.
 
@@ -200,7 +204,7 @@ class RAG:
         self._debug = True
         return self
 
-    def _build_prompt(self, query, context):
+    def _build_prompt(self, query: str, context: str) -> str:
         """Build the final prompt sent to the LLM, with optional memory."""
         tool_ctx = ""
         if self._tools:
@@ -228,7 +232,7 @@ class RAG:
             f"Question: {query}\nAnswer:"
         )
 
-    def run(self, query, schema=None):
+    def run(self, query: str, schema: Any = None) -> Any:
         """
         Run a single query against the indexed documents.
 
@@ -272,7 +276,7 @@ class RAG:
 
         return answer
 
-    def chat(self, query):
+    def chat(self, query: str) -> str:
         """
         Run a query with memory enabled.
 
@@ -292,7 +296,7 @@ class RAG:
         self._memory = True
         return self.run(query)
 
-    def stream(self, query):
+    def stream(self, query: str) -> Iterator[str]:
         """
         Run a query and stream the response token by token.
 
@@ -330,7 +334,7 @@ class RAG:
 
         yield from self._llm.stream(prompt)
 
-    def reset_memory(self):
+    def reset_memory(self) -> "RAG":
         """
         Clear the conversation history.
 

--- a/fenn/agents/rag/rag_node.py
+++ b/fenn/agents/rag/rag_node.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fenn.agents import Node
 
 from .loader import load_documents
@@ -47,19 +49,19 @@ class RAGNode(Node):
 
     def __init__(
         self,
-        sources=None,
-        query_key="query",
-        context_key="rag_context",
-        chunks_key="rag_chunks",
-        top_k=5,
-        next_action="default",
-        faiss=False,
-        embedding_provider="local",
-        embedding_model="all-MiniLM-L6-v2",
-        embedding_api_key=None,
-        chunk_mode="smart",
-        persist_path=None,
-    ):
+        sources: str | list[str] | None = None,
+        query_key: str = "query",
+        context_key: str = "rag_context",
+        chunks_key: str = "rag_chunks",
+        top_k: int = 5,
+        next_action: str = "default",
+        faiss: bool = False,
+        embedding_provider: str = "local",
+        embedding_model: str = "all-MiniLM-L6-v2",
+        embedding_api_key: str | None = None,
+        chunk_mode: str = "smart",
+        persist_path: str | None = None,
+    ) -> None:
         super().__init__()
         self._query_key = query_key
         self._context_key = context_key
@@ -82,18 +84,18 @@ class RAGNode(Node):
             for s in sources:
                 self._retriever.index(load_documents(s))
 
-    def add_source(self, source):
+    def add_source(self, source: str) -> "RAGNode":
         """Index an additional source. Returns self for chaining."""
         self._retriever.index(load_documents(source))
         return self
 
-    def prep(self, shared):
+    def prep(self, shared: dict[str, Any]) -> str:
         return shared.get(self._query_key, "")
 
-    def exec(self, query):
+    def exec(self, query: str) -> list[str]:
         return self._retriever.query(query, top_k=self._top_k)
 
-    def post(self, shared, query, chunks):
+    def post(self, shared: dict[str, Any], query: str, chunks: list[str]) -> str:
         shared[self._chunks_key] = chunks
         shared[self._context_key] = "\n\n".join(chunks)
         return self._next_action


### PR DESCRIPTION
﻿## Summary
- Add method input and return type annotations to `fenn.agents.rag.rag_node.py`
- Add method input and return type annotations to `fenn.agents.rag.rag.py`
- Keep runtime behavior unchanged

Fixes #210

## Validation
- `python -m ruff format --check fenn\agents\rag\rag.py fenn\agents\rag\rag_node.py`
- `python -m ruff check fenn\agents\rag\rag.py fenn\agents\rag\rag_node.py`
- `nox -f fenn\noxfile.py -t fenn` from parent workspace, equivalent to `nox -t fenn` in the repo: 519 passed, 1 skipped
