### PR TITLE
Add typing to agent node and tools modules

### DIFF
--- a/fenn/agents/node.py
+++ b/fenn/agents/node.py
@@ -1,19 +1,38 @@
-from typing import Any
+from typing import Any, TypeAlias, cast
 
 from fenn.agents import Node
 from fenn.agents.tools import execute_tool
 
+SharedData: TypeAlias = dict[str, Any]
+ThinkPrepResult: TypeAlias = dict[str, Any]
+
+
+def _parse_tool_call(prep_res: str) -> tuple[str, list[str]]:
+    """Extract a tool name and arguments from an action line."""
+    if "Action:" in prep_res:
+        action_line = next(
+            line for line in prep_res.split("\n") if line.startswith("Action:")
+        )
+        tool_call = action_line.replace("Action:", "").strip()
+    else:
+        tool_call = prep_res.strip()
+
+    tool_name = tool_call.split("(")[0]
+    args_str = tool_call.split("(")[1].rstrip(")")
+    tool_args = [arg.strip() for arg in args_str.split(",")]
+    return tool_name, tool_args
+
 
 class ThinkNode(Node):
-    def prep(self, shared: dict[str, Any]) -> dict[str, Any]:
+    def prep(self, shared: SharedData) -> ThinkPrepResult:
         return {"llm": shared["llm"], "messages": shared["messages"]}
 
-    def exec(self, prep_res: dict[str, Any]) -> Any:
+    def exec(self, prep_res: ThinkPrepResult) -> str:
         llm = prep_res["llm"]
         response = llm.chat_complete(prep_res["messages"])
-        return response
+        return cast(str, response)
 
-    def post(self, shared: dict[str, Any], prep_res: Any, exec_res: Any) -> str:
+    def post(self, shared: SharedData, prep_res: ThinkPrepResult, exec_res: str) -> str:
         shared["last_thought"] = exec_res
         shared["messages"].append({"role": "assistant", "content": exec_res})
         if "Action:" in exec_res:
@@ -22,21 +41,11 @@ class ThinkNode(Node):
 
 
 class ActNode(Node):
-    def prep(self, shared: dict[str, Any]) -> Any:
-        return shared["last_thought"]
+    def prep(self, shared: SharedData) -> str:
+        return cast(str, shared["last_thought"])
 
-    def exec(self, thought: str) -> Any:
-        if "Action:" in thought:
-            action_line = [
-                line for line in thought.split("\n") if line.startswith("Action:")
-            ][0]
-            tool_call = action_line.replace("Action:", "").strip()
-        else:
-            tool_call = thought.strip()
-
-        tool_name = tool_call.split("(")[0]
-        args_str = tool_call.split("(")[1].rstrip(")")
-        tool_args = [arg.strip() for arg in args_str.split(",")]
+    def exec(self, prep_res: str) -> str:
+        tool_name, tool_args = _parse_tool_call(prep_res)
 
         try:
             result = execute_tool(tool_name, *tool_args)
@@ -49,21 +58,21 @@ class ActNode(Node):
             OSError,
         ) as e:
             result = f"Error: {e}"
-        return result
+        return cast(str, result)
 
-    def post(self, shared: dict[str, Any], prep_res: Any, exec_res: Any) -> str:
+    def post(self, shared: SharedData, prep_res: str, exec_res: str) -> str:
         shared["last_observation"] = exec_res
         return "observe"
 
 
 class ObserveNode(Node):
-    def prep(self, shared: dict[str, Any]) -> Any:
-        return shared["last_observation"]
+    def prep(self, shared: SharedData) -> str:
+        return cast(str, shared["last_observation"])
 
-    def exec(self, observation: Any) -> Any:
-        return observation
+    def exec(self, prep_res: str) -> str:
+        return prep_res
 
-    def post(self, shared: dict[str, Any], prep_res: Any, exec_res: Any) -> str:
+    def post(self, shared: SharedData, prep_res: str, exec_res: str) -> str:
         shared["messages"].append(
             {"role": "user", "content": f"Observation: {exec_res}"}
         )

--- a/fenn/agents/tools.py
+++ b/fenn/agents/tools.py
@@ -1,22 +1,38 @@
 import inspect
 from collections.abc import Callable
 from functools import wraps
-from typing import Any
+from typing import Any, ParamSpec, TypeAlias, TypedDict, TypeVar
 
-TOOLS_REGISTRY: dict[str, dict[str, Any]] = {}
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
-def tool(func: Callable[..., Any]) -> Callable[..., Any]:
+class ToolSchema(TypedDict):
+    name: str
+    description: str
+
+
+class ToolEntry(TypedDict):
+    schema: ToolSchema
+    execute: Callable[..., Any]
+
+
+ToolRegistry: TypeAlias = dict[str, ToolEntry]
+
+TOOLS_REGISTRY: ToolRegistry = {}
+
+
+def tool(func: Callable[P, R]) -> Callable[P, R]:
     """
     A decorator that registers an executable function as a tool
     """
 
     @wraps(func)
-    def decorator(*args: Any, **kwargs: Any) -> Any:
+    def decorator(*args: P.args, **kwargs: P.kwargs) -> R:
         return func(*args, **kwargs)
 
-    tool_name = func.__name__
-    tools_description = inspect.getdoc(func) or "No description provided"
+    tool_name: str = func.__name__
+    tools_description: str = inspect.getdoc(func) or "No description provided"
 
     TOOLS_REGISTRY[tool_name] = {
         "schema": {"name": tool_name, "description": tools_description},
@@ -25,7 +41,7 @@ def tool(func: Callable[..., Any]) -> Callable[..., Any]:
     return decorator
 
 
-def get_tool_schema() -> list[dict[str, Any]]:
+def get_tool_schema() -> list[ToolSchema]:
     return [info["schema"] for info in TOOLS_REGISTRY.values()]
 
 


### PR DESCRIPTION
Addresses #208 by adding explicit type aliases and annotations to fenn/agents/node.py and fenn/agents/tools.py.\n\nVerification:\n- uv run ruff check fenn/agents/node.py fenn/agents/tools.py\n- uv run pytest tests/unit/agents/test_node.py tests/unit/agents/test_tools.py