### PR TITLE
fix: silent ValueError in remove_service, missing print() guard, and Parser.reset()

### DIFF
--- a/fenn/logging.py
+++ b/fenn/logging.py
@@ -183,6 +183,8 @@ class FennLogger(XmlMixin, logging.LoggerAdapter):
         args: dict[str, Any],
         config_file: str,
     ) -> None:
+        if not args:
+            return
         flat_config = self._flatten_dict(args)
         self._form_log_paths(args=args)
         self._display_config(

--- a/fenn/notification/notifier.py
+++ b/fenn/notification/notifier.py
@@ -44,10 +44,7 @@ class Notifier:
         try:
             self._services.remove(service())
         except ValueError:
-            ValueError(
-                f"Service {service.__class__.__name__} not found in services list"
-            )
-            raise
+            raise ValueError(f"Service {service.__name__} not found in services list")
 
     def notify(self, message: str) -> None:
         """Send notification to all registered services.

--- a/fenn/parser.py
+++ b/fenn/parser.py
@@ -11,6 +11,13 @@ from fenn.logging import logger
 class Parser:
     _instance = None
 
+    @classmethod
+    def reset(cls) -> None:
+        """Reset singleton state. Use between tests or distinct Fenn instances.
+        Note: all existing Parser references become stale after calling this.
+        """
+        cls._instance = None
+
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
@@ -18,7 +25,7 @@ class Parser:
 
     def __init__(self, config_file: str | Path = "fenn.yaml") -> None:
         if hasattr(self, "_initialized"):
-            return
+            return  # singleton: __init__ is a no-op after first construction
 
         self._config_file: Path = Path(config_file)
         self._args: dict[str, Any] = {}
@@ -53,6 +60,11 @@ class Parser:
 
     def print(self) -> None:
         """Public method to trigger the flattened print with colored paths."""
+        if not self._args:
+            raise RuntimeError(
+                "Parser.print() called before load_configuration(). "
+                "Call load_configuration() first."
+            )
         logger.write_config(self._args, self.config_file)
 
     @property


### PR DESCRIPTION
**Summary**
Fixed three bugs found while reading the source: a silent exception discard in Notifier.remove_service(), a pre-condition gap in Parser.print() / FennLogger._create_config(), and missing singleton reset support in Parser.

**Changes**
`fenn/notification/notifier.py` :  In remove_service(): replaced the discarded-object pattern (ValueError(...) without raise + bare raise) with a single raise ValueError(...). Also fixed service.__class__.__name__ → service.__name__ because service is a class (type[Service]), not an instance, the old code always produced "type".
`fenn/parser.py` : Added a precondition guard in Parser.print(): raises RuntimeError with a clear message if called before load_configuration() (when self._args is still {}), preventing a confusing KeyError: 'logger' four frames into the call stack. Also added Parser.reset() classmethod to clear singleton state between tests or distinct Fenn instances.
`fenn/logging.py` : Added a defensive early-return guard in FennLogger._create_config() for the empty-args case, consistent with the parser-side guard above.

_Notes_
Bug 3 (singleton) is fixed minimally here with a reset() escape hatch. A fuller fix replacing the singleton with explicit dependency injection in Fenn.__init__  is a larger refactor that should be tracked separately.