### PR TITLE
chore: add commitizen to pre-commit for commit message check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,8 @@ repos:
         pass_filenames: false
         types: [python]
         args: [fenn/, --exit-zero]
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.4.2
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]


### PR DESCRIPTION
Fixes #179. This adds the commitizen hook to .pre-commit-config.yaml to enforce conventional commit messages.