### PR TITLE
feat(core): enable human-readable session IDs

### DIFF
--- a/fenn/reproducibility.py
+++ b/fenn/reproducibility.py
@@ -32,29 +32,29 @@ def generate_session_id() -> str:
     timestamp = datetime.now().strftime("%Y%m%d_%H%M")
 
     # A curated list of "beautiful" words
-    # adjectives = [
-    #    "autumn", "hidden", "bitter", "misty", "silent",
-    #    "empty", "dry", "dark", "summer", "icy", "delicate",
-    #    "quiet", "white", "cool", "spring", "winter", "patient",
-    #    "twilight", "dawn", "crimson", "wispy", "weathered",
-    #    "blue", "billowing", "broken", "cold", "damp", "falling",
-    #    "frosty", "green", "long", "late", "lingering"
-    # ]
+    adjectives = [
+       "autumn", "hidden", "bitter", "misty", "silent",
+       "empty", "dry", "dark", "summer", "icy", "delicate",
+       "quiet", "white", "cool", "spring", "winter", "patient",
+       "twilight", "dawn", "crimson", "wispy", "weathered",
+       "blue", "billowing", "broken", "cold", "damp", "falling",
+       "frosty", "green", "long", "late", "lingering"
+    ]
 
-    # nouns = [
-    #    "waterfall", "river", "breeze", "moon", "rain",
-    #    "wind", "sea", "morning", "snow", "lake", "sunset",
-    #    "pine", "shadow", "leaf", "dawn", "glitter", "forest",
-    #    "hill", "cloud", "meadow", "sun", "glade", "bird",
-    #    "brook", "butterfly", "bush", "dew", "dust", "field",
-    #    "fire", "flower", "firefly", "feather", "grass"
-    # ]
+    nouns = [
+       "waterfall", "river", "breeze", "moon", "rain",
+       "wind", "sea", "morning", "snow", "lake", "sunset",
+       "pine", "shadow", "leaf", "dawn", "glitter", "forest",
+       "hill", "cloud", "meadow", "sun", "glade", "bird",
+       "brook", "butterfly", "bush", "dew", "dust", "field",
+       "fire", "flower", "firefly", "feather", "grass"
+    ]
 
     # Select words
-    # adj = random.choice(adjectives)
-    # noun = random.choice(nouns)
+    adj = random.choice(adjectives)
+    noun = random.choice(nouns)
 
     # Add a secure hex suffix (2 bytes = 4 hex chars) to ensure uniqueness
     hex_suffix = secrets.token_hex(2)
 
-    return timestamp + "_" + hex_suffix
+    return f"{timestamp}_{adj}_{noun}_{hex_suffix}"


### PR DESCRIPTION
Uncomments and restores the original logic to generate human-readable, memorable session IDs (e.g. `20260707_1234_silent_waterfall_a1b2`). This vastly improves readability in dashboard logs compared to pure hex strings.