### PR TITLE
feat(nn): [#230] Add MLPClassifier and MLPRegressor models

### DIFF
--- a/fenn/nn/models/__init__.py
+++ b/fenn/nn/models/__init__.py
@@ -1,0 +1,3 @@
+from .mlp import MLPClassifier, MLPRegressor
+
+__all__ = ["MLPClassifier", "MLPRegressor"]

--- a/fenn/nn/models/mlp.py
+++ b/fenn/nn/models/mlp.py
@@ -1,0 +1,372 @@
+"""Scikit-learn-inspired Multi-Layer Perceptron models.
+
+This module provides :class:`MLPClassifier` and :class:`MLPRegressor`, two
+high-level estimators for users who want to train a simple feed-forward
+neural network without writing any PyTorch training code themselves.
+
+Both classes build a plain ``torch.nn.Sequential`` MLP internally and
+delegate the entire training loop to fenn's existing trainers
+(:class:`~fenn.nn.trainers.ClassificationTrainer` and
+:class:`~fenn.nn.trainers.RegressionTrainer`). No training logic lives in
+this module.
+
+The public API intentionally mirrors scikit-learn's
+``sklearn.neural_network.MLPClassifier`` / ``MLPRegressor``. See
+https://scikit-learn.org/stable/modules/neural_networks_supervised.html
+for the API this module takes inspiration from.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as torch_optim
+from torch.utils.data import DataLoader, TensorDataset
+
+from fenn.nn.trainers import ClassificationTrainer, RegressionTrainer
+
+_ACTIVATIONS = {
+    "relu": nn.ReLU,
+    "tanh": nn.Tanh,
+    "logistic": nn.Sigmoid,
+    "identity": nn.Identity,
+}
+
+_SOLVERS = {
+    "adam": torch_optim.Adam,
+    "sgd": torch_optim.SGD,
+}
+
+
+def _build_mlp(
+    input_size: int,
+    hidden_layer_sizes: Sequence[int],
+    output_size: int,
+    activation: str,
+) -> nn.Sequential:
+    """Build a feed-forward MLP as a ``torch.nn.Sequential`` stack.
+
+    Args:
+        input_size: Number of input features.
+        hidden_layer_sizes: Number of units in each hidden layer, e.g. ``(100,)``.
+        output_size: Number of output units (number of classes for
+            multi-class classification, ``1`` for binary classification or
+            regression).
+        activation: Activation applied after each hidden layer. One of
+            ``'relu'``, ``'tanh'``, ``'logistic'``, ``'identity'``.
+
+    Returns:
+        A ``torch.nn.Sequential`` module. No activation is applied to the
+        final layer; outputs are raw logits (classification) or raw
+        predictions (regression).
+
+    Raises:
+        ValueError: If ``activation`` is not a recognized name.
+    """
+    if activation not in _ACTIVATIONS:
+        raise ValueError(
+            f"Unknown activation '{activation}'. Must be one of {list(_ACTIVATIONS)}."
+        )
+
+    activation_cls = _ACTIVATIONS[activation]
+
+    layers: list[nn.Module] = []
+    in_features = input_size
+    for units in hidden_layer_sizes:
+        layers.append(nn.Linear(in_features, units))
+        layers.append(activation_cls())
+        in_features = units
+
+    layers.append(nn.Linear(in_features, output_size))
+    return nn.Sequential(*layers)
+
+
+def _to_tensor(data) -> torch.Tensor:
+    """Convert array-like input (list, numpy array, or tensor) to a float tensor."""
+    if torch.is_tensor(data):
+        return data.float()
+    return torch.as_tensor(np.asarray(data), dtype=torch.float32)
+
+
+def _make_loader(
+    X: torch.Tensor, y: torch.Tensor, batch_size: int, shuffle: bool
+) -> DataLoader:
+    dataset = TensorDataset(X, y)
+    return DataLoader(
+        dataset, batch_size=min(batch_size, len(dataset)), shuffle=shuffle
+    )
+
+
+class BaseMLP:
+    """Shared setup logic for :class:`MLPClassifier` and :class:`MLPRegressor`.
+
+    This class is not meant to be instantiated directly; use one of the two
+    subclasses instead.
+
+    Args:
+        hidden_layer_sizes: Number of neurons in each hidden layer, e.g.
+            ``(100,)`` for a single hidden layer of 100 units, or
+            ``(64, 32)`` for two hidden layers.
+        activation: Activation function for the hidden layers. One of
+            ``'relu'``, ``'tanh'``, ``'logistic'``, ``'identity'``.
+        solver: Optimizer used to train the weights. One of ``'adam'``, ``'sgd'``.
+        learning_rate_init: Initial learning rate used by the optimizer.
+        batch_size: Size of minibatches used during training.
+        max_iter: Maximum number of training epochs.
+        early_stopping: Whether to hold out ``validation_fraction`` of the
+            training data and stop training when validation loss stops
+            improving for ``n_iter_no_change`` epochs.
+        n_iter_no_change: Number of epochs with no improvement to wait
+            before stopping, when ``early_stopping=True``.
+        validation_fraction: Proportion of training data to set aside for
+            early stopping validation, when ``early_stopping=True``.
+        device: Device to train on, e.g. ``'cpu'``, ``'cuda'``, ``'mps'``.
+    """
+
+    def __init__(
+        self,
+        hidden_layer_sizes: Sequence[int] = (100,),
+        activation: str = "relu",
+        solver: str = "adam",
+        learning_rate_init: float = 0.001,
+        batch_size: int = 32,
+        max_iter: int = 200,
+        early_stopping: bool = False,
+        n_iter_no_change: int = 10,
+        validation_fraction: float = 0.1,
+        device: str = "cpu",
+    ):
+        if solver not in _SOLVERS:
+            raise ValueError(
+                f"Unknown solver '{solver}'. Must be one of {list(_SOLVERS)}."
+            )
+        if not (0.0 < validation_fraction < 1.0):
+            raise ValueError("validation_fraction must be between 0 and 1.")
+        if len(hidden_layer_sizes) == 0:
+            raise ValueError("hidden_layer_sizes must contain at least one layer.")
+
+        self.hidden_layer_sizes = tuple(hidden_layer_sizes)
+        self.activation = activation
+        self.solver = solver
+        self.learning_rate_init = learning_rate_init
+        self.batch_size = batch_size
+        self.max_iter = max_iter
+        self.early_stopping = early_stopping
+        self.n_iter_no_change = n_iter_no_change
+        self.validation_fraction = validation_fraction
+        self.device = device
+
+        self._model: nn.Module | None = None
+        self._trainer: ClassificationTrainer | RegressionTrainer | None = None
+        self.n_features_in_: int | None = None
+
+    def _split_validation(self, X: torch.Tensor, y: torch.Tensor):
+        """Hold out a deterministic validation split for early stopping."""
+        n_val = max(1, int(len(X) * self.validation_fraction))
+        X_train, X_val = X[:-n_val], X[-n_val:]
+        y_train, y_val = y[:-n_val], y[-n_val:]
+        return X_train, y_train, X_val, y_val
+
+    def _make_optimizer(self) -> torch.optim.Optimizer:
+        return _SOLVERS[self.solver](
+            self._model.parameters(), lr=self.learning_rate_init
+        )
+
+    def _check_is_fitted(self) -> None:
+        if self._trainer is None:
+            raise RuntimeError(
+                f"This {type(self).__name__} instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this estimator."
+            )
+
+
+class MLPClassifier(BaseMLP):
+    """Multi-layer Perceptron classifier.
+
+    A scikit-learn-style estimator for feed-forward neural network
+    classification. Supports both binary and multi-class classification;
+    the number of classes is inferred automatically from the labels passed
+    to :meth:`fit`. Internally builds a ``torch.nn.Sequential`` MLP and
+    delegates all training to
+    :class:`~fenn.nn.trainers.ClassificationTrainer`.
+
+    Example:
+        >>> clf = MLPClassifier(hidden_layer_sizes=(64, 32), max_iter=50)
+        >>> clf.fit(X_train, y_train)
+        >>> clf.predict(X_test)
+
+    Note:
+        Multi-label classification is not yet supported by this estimator,
+        even though the underlying :class:`ClassificationTrainer` supports it.
+    """
+
+    def fit(self, X, y) -> "MLPClassifier":
+        """Fit the MLP classifier on the given training data.
+
+        Args:
+            X: Array-like of shape ``(n_samples, n_features)``.
+            y: Array-like of shape ``(n_samples,)`` with class labels.
+                Labels do not need to be pre-encoded as integers.
+
+        Returns:
+            self
+        """
+        X_t = _to_tensor(X)
+        y_arr = np.asarray(y)
+        self.classes_ = np.unique(y_arr)
+        num_classes = len(self.classes_)
+
+        if num_classes < 2:
+            raise ValueError("MLPClassifier requires at least 2 distinct classes in y.")
+
+        # Encode labels as class indices (0..num_classes-1) based on sorted classes_.
+        label_to_index = {label: idx for idx, label in enumerate(self.classes_)}
+        y_encoded = np.array([label_to_index[label] for label in y_arr])
+        y_t = torch.as_tensor(y_encoded, dtype=torch.long)
+
+        self.n_features_in_ = X_t.shape[1]
+        out_features = 1 if num_classes == 2 else num_classes
+        self._model = _build_mlp(
+            self.n_features_in_, self.hidden_layer_sizes, out_features, self.activation
+        )
+
+        loss_fn = nn.BCEWithLogitsLoss() if num_classes == 2 else nn.CrossEntropyLoss()
+        optimizer = self._make_optimizer()
+
+        self._trainer = ClassificationTrainer(
+            model=self._model,
+            loss_fn=loss_fn,
+            optim=optimizer,
+            num_classes=num_classes,
+            device=self.device,
+            early_stopping_patience=self.n_iter_no_change
+            if self.early_stopping
+            else None,
+        )
+
+        val_loader = None
+        if self.early_stopping:
+            X_train, y_train, X_val, y_val = self._split_validation(X_t, y_t)
+            train_loader = _make_loader(X_train, y_train, self.batch_size, shuffle=True)
+            val_loader = _make_loader(X_val, y_val, self.batch_size, shuffle=False)
+        else:
+            train_loader = _make_loader(X_t, y_t, self.batch_size, shuffle=True)
+
+        self._trainer.fit(train_loader, epochs=self.max_iter, val_loader=val_loader)
+        return self
+
+    def predict(self, X) -> np.ndarray:
+        """Predict class labels for samples in ``X``.
+
+        Args:
+            X: Array-like of shape ``(n_samples, n_features)``.
+
+        Returns:
+            Array of shape ``(n_samples,)`` with predicted labels, using the
+            original label values seen during :meth:`fit`.
+        """
+        self._check_is_fitted()
+        X_t = _to_tensor(X)
+        preds = self._trainer.predict(X_t)
+        return self.classes_[np.asarray(preds)]
+
+    def predict_proba(self, X) -> np.ndarray:
+        """Predict class probabilities for samples in ``X``.
+
+        Args:
+            X: Array-like of shape ``(n_samples, n_features)``.
+
+        Returns:
+            Array of shape ``(n_samples, n_classes)`` with predicted
+            probabilities for each class, ordered as in ``self.classes_``.
+        """
+        self._check_is_fitted()
+        X_t = _to_tensor(X)
+        _, proba = self._trainer.predict(X_t, return_proba=True)
+        proba_arr = np.asarray(proba)
+        if proba_arr.ndim == 1:
+            # Binary case: trainer returns P(class 1); expand to two columns.
+            proba_arr = np.stack([1 - proba_arr, proba_arr], axis=1)
+        return proba_arr
+
+    def score(self, X, y) -> float:
+        """Return the mean accuracy on the given test data and labels."""
+        preds = self.predict(X)
+        return float(np.mean(np.asarray(preds) == np.asarray(y)))
+
+
+class MLPRegressor(BaseMLP):
+    """Multi-layer Perceptron regressor.
+
+    A scikit-learn-style estimator for feed-forward neural network
+    regression on a single continuous target. Internally builds a
+    ``torch.nn.Sequential`` MLP with a single output unit and delegates all
+    training to :class:`~fenn.nn.trainers.RegressionTrainer`.
+
+    Example:
+        >>> reg = MLPRegressor(hidden_layer_sizes=(64, 32), max_iter=50)
+        >>> reg.fit(X_train, y_train)
+        >>> reg.predict(X_test)
+    """
+
+    def fit(self, X, y) -> "MLPRegressor":
+        """Fit the MLP regressor on the given training data.
+
+        Args:
+            X: Array-like of shape ``(n_samples, n_features)``.
+            y: Array-like of shape ``(n_samples,)`` with continuous targets.
+
+        Returns:
+            self
+        """
+        X_t = _to_tensor(X)
+        y_t = _to_tensor(y).view(-1, 1)
+
+        self.n_features_in_ = X_t.shape[1]
+        self._model = _build_mlp(
+            self.n_features_in_, self.hidden_layer_sizes, 1, self.activation
+        )
+
+        loss_fn = nn.MSELoss()
+        optimizer = self._make_optimizer()
+
+        self._trainer = RegressionTrainer(
+            model=self._model,
+            loss_fn=loss_fn,
+            optim=optimizer,
+            device=self.device,
+            early_stopping_patience=self.n_iter_no_change
+            if self.early_stopping
+            else None,
+        )
+
+        val_loader = None
+        if self.early_stopping:
+            X_train, y_train, X_val, y_val = self._split_validation(X_t, y_t)
+            train_loader = _make_loader(X_train, y_train, self.batch_size, shuffle=True)
+            val_loader = _make_loader(X_val, y_val, self.batch_size, shuffle=False)
+        else:
+            train_loader = _make_loader(X_t, y_t, self.batch_size, shuffle=True)
+
+        self._trainer.fit(train_loader, epochs=self.max_iter, val_loader=val_loader)
+        return self
+
+    def predict(self, X) -> np.ndarray:
+        """Predict continuous targets for samples in ``X``."""
+        self._check_is_fitted()
+        X_t = _to_tensor(X)
+        preds = self._trainer.predict(X_t)
+        return np.asarray(preds)
+
+    def score(self, X, y) -> float:
+        """Return the coefficient of determination (R^2) on the given test data."""
+        preds = self.predict(X)
+        y_arr = np.asarray(y, dtype=float)
+        ss_res = np.sum((y_arr - preds) ** 2)
+        ss_tot = np.sum((y_arr - np.mean(y_arr)) ** 2)
+        if ss_tot == 0:
+            return 0.0
+        return float(1 - ss_res / ss_tot)

--- a/fenn/nn/models/mlp.py
+++ b/fenn/nn/models/mlp.py
@@ -170,10 +170,8 @@ class BaseMLP:
         y_train, y_val = y[:-n_val], y[-n_val:]
         return X_train, y_train, X_val, y_val
 
-    def _make_optimizer(self) -> torch.optim.Optimizer:
-        return _SOLVERS[self.solver](
-            self._model.parameters(), lr=self.learning_rate_init
-        )
+    def _make_optimizer(self, model: nn.Module) -> torch.optim.Optimizer:
+        return _SOLVERS[self.solver](model.parameters(), lr=self.learning_rate_init)
 
     def _check_is_fitted(self) -> None:
         if self._trainer is None:
@@ -203,6 +201,9 @@ class MLPClassifier(BaseMLP):
         even though the underlying :class:`ClassificationTrainer` supports it.
     """
 
+    _trainer: ClassificationTrainer | None
+    classes_: np.ndarray
+
     def fit(self, X, y) -> "MLPClassifier":
         """Fit the MLP classifier on the given training data.
 
@@ -229,15 +230,16 @@ class MLPClassifier(BaseMLP):
 
         self.n_features_in_ = X_t.shape[1]
         out_features = 1 if num_classes == 2 else num_classes
-        self._model = _build_mlp(
+        model = _build_mlp(
             self.n_features_in_, self.hidden_layer_sizes, out_features, self.activation
         )
+        self._model = model
 
         loss_fn = nn.BCEWithLogitsLoss() if num_classes == 2 else nn.CrossEntropyLoss()
-        optimizer = self._make_optimizer()
+        optimizer = self._make_optimizer(model)
 
-        self._trainer = ClassificationTrainer(
-            model=self._model,
+        trainer = ClassificationTrainer(
+            model=model,
             loss_fn=loss_fn,
             optim=optimizer,
             num_classes=num_classes,
@@ -246,6 +248,7 @@ class MLPClassifier(BaseMLP):
             if self.early_stopping
             else None,
         )
+        self._trainer = trainer
 
         val_loader = None
         if self.early_stopping:
@@ -255,7 +258,7 @@ class MLPClassifier(BaseMLP):
         else:
             train_loader = _make_loader(X_t, y_t, self.batch_size, shuffle=True)
 
-        self._trainer.fit(train_loader, epochs=self.max_iter, val_loader=val_loader)
+        trainer.fit(train_loader, epochs=self.max_iter, val_loader=val_loader)
         return self
 
     def predict(self, X) -> np.ndarray:
@@ -269,6 +272,7 @@ class MLPClassifier(BaseMLP):
             original label values seen during :meth:`fit`.
         """
         self._check_is_fitted()
+        assert self._trainer is not None
         X_t = _to_tensor(X)
         preds = self._trainer.predict(X_t)
         return self.classes_[np.asarray(preds)]
@@ -284,6 +288,7 @@ class MLPClassifier(BaseMLP):
             probabilities for each class, ordered as in ``self.classes_``.
         """
         self._check_is_fitted()
+        assert self._trainer is not None
         X_t = _to_tensor(X)
         _, proba = self._trainer.predict(X_t, return_proba=True)
         proba_arr = np.asarray(proba)
@@ -312,6 +317,8 @@ class MLPRegressor(BaseMLP):
         >>> reg.predict(X_test)
     """
 
+    _trainer: RegressionTrainer | None
+
     def fit(self, X, y) -> "MLPRegressor":
         """Fit the MLP regressor on the given training data.
 
@@ -326,15 +333,16 @@ class MLPRegressor(BaseMLP):
         y_t = _to_tensor(y).view(-1, 1)
 
         self.n_features_in_ = X_t.shape[1]
-        self._model = _build_mlp(
+        model = _build_mlp(
             self.n_features_in_, self.hidden_layer_sizes, 1, self.activation
         )
+        self._model = model
 
         loss_fn = nn.MSELoss()
-        optimizer = self._make_optimizer()
+        optimizer = self._make_optimizer(model)
 
-        self._trainer = RegressionTrainer(
-            model=self._model,
+        trainer = RegressionTrainer(
+            model=model,
             loss_fn=loss_fn,
             optim=optimizer,
             device=self.device,
@@ -342,6 +350,7 @@ class MLPRegressor(BaseMLP):
             if self.early_stopping
             else None,
         )
+        self._trainer = trainer
 
         val_loader = None
         if self.early_stopping:
@@ -351,12 +360,13 @@ class MLPRegressor(BaseMLP):
         else:
             train_loader = _make_loader(X_t, y_t, self.batch_size, shuffle=True)
 
-        self._trainer.fit(train_loader, epochs=self.max_iter, val_loader=val_loader)
+        trainer.fit(train_loader, epochs=self.max_iter, val_loader=val_loader)
         return self
 
     def predict(self, X) -> np.ndarray:
         """Predict continuous targets for samples in ``X``."""
         self._check_is_fitted()
+        assert self._trainer is not None
         X_t = _to_tensor(X)
         preds = self._trainer.predict(X_t)
         return np.asarray(preds)

--- a/tests/unit/nn/test_mlp.py
+++ b/tests/unit/nn/test_mlp.py
@@ -1,0 +1,245 @@
+"""Tests for fenn/nn/models/mlp.py"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+from fenn.nn.models.mlp import MLPClassifier, MLPRegressor, _build_mlp
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _mock_rich_progress():
+    """Avoid real rich.progress.Progress Live displays during tests.
+
+    The underlying trainers render a live progress bar on every `fit()` call.
+    Instantiating many real ``Progress``/``Live`` displays within the same
+    pytest session is flaky (rich raises ``LiveError: Only one live display
+    may be active at once``), so - like the existing trainer tests - we
+    replace it with a no-op mock and let the actual training logic run for
+    real.
+    """
+
+    def _fake_progress(*args, **kwargs):
+        mock_progress = MagicMock()
+        mock_progress.add_task.return_value = MagicMock()
+        return mock_progress
+
+    with patch(
+        "fenn.nn.trainers.classification_trainer.Progress", side_effect=_fake_progress
+    ):
+        with patch(
+            "fenn.nn.trainers.regression_trainer.Progress", side_effect=_fake_progress
+        ):
+            yield
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _make_classification_data(n_samples=40, n_features=4, n_classes=2, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(n_samples, n_features))
+    weights = rng.normal(size=(n_features,))
+    scores = X @ weights
+    if n_classes == 2:
+        y = (scores > np.median(scores)).astype(int)
+    else:
+        thresholds = np.quantile(scores, np.linspace(0, 1, n_classes + 1)[1:-1])
+        y = np.digitize(scores, thresholds)
+    return X, y
+
+
+def _make_regression_data(n_samples=40, n_features=4, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(n_samples, n_features))
+    weights = rng.normal(size=(n_features,))
+    y = X @ weights + 0.01 * rng.normal(size=(n_samples,))
+    return X, y
+
+
+# ── _build_mlp ─────────────────────────────────────────────────────────────────
+
+
+class TestBuildMLP:
+    def test_layer_shapes(self):
+        model = _build_mlp(
+            input_size=4, hidden_layer_sizes=(8, 6), output_size=3, activation="relu"
+        )
+        linears = [m for m in model if isinstance(m, torch.nn.Linear)]
+        assert [linear.in_features for linear in linears] == [4, 8, 6]
+        assert [linear.out_features for linear in linears] == [8, 6, 3]
+
+    def test_no_activation_on_output_layer(self):
+        model = _build_mlp(
+            input_size=4, hidden_layer_sizes=(8,), output_size=2, activation="relu"
+        )
+        assert isinstance(model[-1], torch.nn.Linear)
+
+    def test_unknown_activation_raises(self):
+        with pytest.raises(ValueError, match="Unknown activation"):
+            _build_mlp(
+                input_size=4, hidden_layer_sizes=(8,), output_size=2, activation="gelu"
+            )
+
+
+# ── BaseMLP validation ─────────────────────────────────────────────────────────
+
+
+class TestBaseMLPValidation:
+    def test_invalid_solver_raises(self):
+        with pytest.raises(ValueError, match="Unknown solver"):
+            MLPClassifier(solver="rmsprop")
+
+    def test_invalid_validation_fraction_raises(self):
+        with pytest.raises(
+            ValueError, match="validation_fraction must be between 0 and 1"
+        ):
+            MLPRegressor(validation_fraction=1.5)
+
+    def test_empty_hidden_layer_sizes_raises(self):
+        with pytest.raises(
+            ValueError, match="hidden_layer_sizes must contain at least one"
+        ):
+            MLPClassifier(hidden_layer_sizes=())
+
+    def test_predict_before_fit_raises(self):
+        with pytest.raises(RuntimeError, match="not fitted yet"):
+            MLPClassifier().predict(np.zeros((2, 3)))
+
+    def test_predict_before_fit_raises_for_regressor(self):
+        with pytest.raises(RuntimeError, match="not fitted yet"):
+            MLPRegressor().predict(np.zeros((2, 3)))
+
+
+# ── MLPClassifier ──────────────────────────────────────────────────────────────
+
+
+class TestMLPClassifierBinary:
+    def test_fit_returns_self(self):
+        X, y = _make_classification_data(n_classes=2)
+        clf = MLPClassifier(hidden_layer_sizes=(8,), max_iter=5, batch_size=8)
+        assert clf.fit(X, y) is clf
+
+    def test_predict_shape_and_values(self):
+        X, y = _make_classification_data(n_classes=2)
+        clf = MLPClassifier(hidden_layer_sizes=(8,), max_iter=5, batch_size=8).fit(X, y)
+        preds = clf.predict(X)
+        assert preds.shape == (len(X),)
+        assert set(np.unique(preds)).issubset(set(clf.classes_))
+
+    def test_predict_proba_shape_and_sums_to_one(self):
+        X, y = _make_classification_data(n_classes=2)
+        clf = MLPClassifier(hidden_layer_sizes=(8,), max_iter=5, batch_size=8).fit(X, y)
+        proba = clf.predict_proba(X)
+        assert proba.shape == (len(X), 2)
+        np.testing.assert_allclose(proba.sum(axis=1), np.ones(len(X)), atol=1e-5)
+
+    def test_learns_better_than_chance(self):
+        X, y = _make_classification_data(n_samples=200, n_classes=2)
+        clf = MLPClassifier(hidden_layer_sizes=(16,), max_iter=60, batch_size=16)
+        clf.fit(X, y)
+        assert clf.score(X, y) > 0.7
+
+    def test_string_labels_round_trip(self):
+        X, y = _make_classification_data(n_classes=2)
+        y_str = np.array(["cat", "dog"])[y]
+        clf = MLPClassifier(hidden_layer_sizes=(8,), max_iter=5, batch_size=8).fit(
+            X, y_str
+        )
+        preds = clf.predict(X)
+        assert set(preds).issubset({"cat", "dog"})
+
+    @pytest.mark.xfail(
+        reason=(
+            "Pre-existing bug in ClassificationTrainer.fit(): the validation branch "
+            "does not reshape labels to (-1, 1) for binary classification the way the "
+            "training branch does, so BCEWithLogitsLoss raises a shape mismatch as soon "
+            "as a val_loader is used with num_classes == 2. Flagged upstream; not fixed "
+            "here since this module must not contain training-loop code. "
+            "See ClassificationTrainer.fit, the '--- VALIDATION ---' block."
+        ),
+        strict=True,
+    )
+    def test_early_stopping_runs(self):
+        X, y = _make_classification_data(n_samples=60, n_classes=2)
+        clf = MLPClassifier(
+            hidden_layer_sizes=(8,),
+            max_iter=10,
+            batch_size=8,
+            early_stopping=True,
+            n_iter_no_change=3,
+        )
+        clf.fit(X, y)
+        assert clf.predict(X).shape == (len(X),)
+
+
+class TestMLPClassifierMulticlass:
+    def test_predict_and_proba_shapes(self):
+        X, y = _make_classification_data(n_samples=60, n_classes=3)
+        clf = MLPClassifier(hidden_layer_sizes=(16,), max_iter=10, batch_size=8).fit(
+            X, y
+        )
+        preds = clf.predict(X)
+        proba = clf.predict_proba(X)
+        assert preds.shape == (len(X),)
+        assert proba.shape == (len(X), 3)
+        np.testing.assert_allclose(proba.sum(axis=1), np.ones(len(X)), atol=1e-5)
+
+    def test_single_class_raises(self):
+        X, y = _make_classification_data(n_classes=2)
+        y[:] = 0
+        with pytest.raises(ValueError, match="at least 2 distinct classes"):
+            MLPClassifier(max_iter=1).fit(X, y)
+
+    def test_early_stopping_runs(self):
+        # Unlike the binary case, multiclass validation does not hit the
+        # pre-existing label-reshape bug in ClassificationTrainer (see
+        # TestMLPClassifierBinary.test_early_stopping_runs), so this path works.
+        X, y = _make_classification_data(n_samples=60, n_classes=3)
+        clf = MLPClassifier(
+            hidden_layer_sizes=(8,),
+            max_iter=10,
+            batch_size=8,
+            early_stopping=True,
+            n_iter_no_change=3,
+        )
+        clf.fit(X, y)
+        assert clf.predict(X).shape == (len(X),)
+
+
+# ── MLPRegressor ───────────────────────────────────────────────────────────────
+
+
+class TestMLPRegressor:
+    def test_fit_returns_self(self):
+        X, y = _make_regression_data()
+        reg = MLPRegressor(hidden_layer_sizes=(8,), max_iter=5, batch_size=8)
+        assert reg.fit(X, y) is reg
+
+    def test_predict_shape(self):
+        X, y = _make_regression_data()
+        reg = MLPRegressor(hidden_layer_sizes=(8,), max_iter=5, batch_size=8).fit(X, y)
+        preds = reg.predict(X)
+        assert preds.shape == (len(X),)
+
+    def test_learns_reasonable_fit(self):
+        X, y = _make_regression_data(n_samples=200)
+        reg = MLPRegressor(hidden_layer_sizes=(16, 8), max_iter=150, batch_size=16)
+        reg.fit(X, y)
+        assert reg.score(X, y) > 0.5
+
+    def test_early_stopping_runs(self):
+        X, y = _make_regression_data(n_samples=60)
+        reg = MLPRegressor(
+            hidden_layer_sizes=(8,),
+            max_iter=10,
+            batch_size=8,
+            early_stopping=True,
+            n_iter_no_change=3,
+        )
+        reg.fit(X, y)
+        assert reg.predict(X).shape == (len(X),)


### PR DESCRIPTION
## Summary
Adds `MLPClassifier` and `MLPRegressor` under `fenn.nn.models.mlp`, giving
users a scikit-learn-style API to train basic MLPs without writing Torch
code. Both estimators build a `torch.nn.Sequential` internally and delegate
all training to the existing `ClassificationTrainer` / `RegressionTrainer` —
no training-loop code added.

## API
- `MLPClassifier(hidden_layer_sizes, activation, solver, learning_rate_init,
  batch_size, max_iter, early_stopping, n_iter_no_change,
  validation_fraction, device)` — `.fit(X, y)`, `.predict(X)`,
  `.predict_proba(X)`, `.score(X, y)`. Handles binary and multi-class;
  labels don't need pre-encoding.
- `MLPRegressor` — same constructor, `.fit`, `.predict`, `.score` (R²).
- Both exported from `fenn.nn.models` and `fenn.nn`.

## Known issue found while testing
`ClassificationTrainer.fit()`'s validation branch doesn't reshape labels to
`(-1, 1)` for binary classification the way the training branch does, so
`BCEWithLogitsLoss` breaks as soon as a `val_loader` is passed with
`num_classes == 2`. I didn't fix it here since this module shouldn't contain
training-loop code — flagged as a test marked `xfail` in
`test_early_stopping_runs` (TestMLPClassifierBinary) with a full explanation.
Happy to open a separate issue/PR for it if that's preferred.

## Testing
20 new unit tests in `tests/unit/nn/test_mlp.py`, covering binary/multiclass
classification, regression, string labels, `predict_proba`, error handling,
and early stopping. `ruff check`, `ruff format --check`, and `typos` all pass.

Fixes #230