### PR TITLE
feat(dashboard)[#231]: rename/delete support for log sessions

### DIFF
--- a/fenn/dashboard/app.py
+++ b/fenn/dashboard/app.py
@@ -204,6 +204,48 @@ def api_session(project_name: str, session_id: str) -> Response:
     return jsonify(data)
 
 
+@app.route("/api/session/<project_name>/<session_id>/rename", methods=["POST"])
+def api_session_rename(
+    project_name: str, session_id: str
+) -> tuple[Response, int] | Response:
+    payload = request.get_json(silent=True)
+    display_name: str | None = None
+    if isinstance(payload, dict):
+        raw_name = payload.get("display_name")
+        if raw_name is not None and not isinstance(raw_name, str):
+            return _api_error(
+                "invalid_param", "display_name must be a string", "display_name"
+            )
+        display_name = raw_name
+    if display_name is None:
+        display_name = request.form.get("display_name")
+    if display_name is None:
+        return _api_error("invalid_param", "display_name is required", "display_name")
+
+    try:
+        ok = scanner.rename_session(project_name, session_id, display_name)
+    except ValueError as e:
+        return _api_error("invalid_param", str(e), "display_name")
+
+    if not ok:
+        abort(404)
+    return jsonify({"display_name": display_name.strip()})
+
+
+@app.route("/api/session/<project_name>/<session_id>/delete", methods=["POST"])
+def api_session_delete(
+    project_name: str, session_id: str
+) -> tuple[Response, int] | Response:
+    try:
+        ok = scanner.delete_session(project_name, session_id)
+    except ValueError as e:
+        return _api_error("invalid_param", str(e), "session_id")
+
+    if not ok:
+        abort(404)
+    return jsonify({"deleted": True})
+
+
 # Pagination / filtering limits. 200 is large enough for any plausible UI
 # without letting a client ask for "everything" by accident.
 _MAX_LIMIT = 200

--- a/fenn/dashboard/scanner.py
+++ b/fenn/dashboard/scanner.py
@@ -1,5 +1,6 @@
 """FnXML file discovery and parsing for the Fenn dashboard."""
 
+import json
 import os
 import time
 from datetime import datetime
@@ -48,6 +49,9 @@ _VALID_SORT_FIELDS = (
     "exception_count",
 )
 
+_DEFAULT_OVERRIDES_PATH = "~/.fenn/dashboard_overrides.json"
+_MAX_DISPLAY_NAME_LENGTH = 200
+
 
 def _running_timeout_s() -> float:
     """Read the running-session timeout from FENN_RUNNING_TIMEOUT_S, with fallback."""
@@ -66,6 +70,10 @@ class FennScanner:
 
     def __init__(self, extra_dirs: list[str] | None = None) -> None:
         self._dirs: list[Path] = []
+        self._overrides_path = Path(
+            os.environ.get("FENN_DASHBOARD_OVERRIDES_PATH", _DEFAULT_OVERRIDES_PATH)
+        ).expanduser()
+        self._overrides: dict[str, dict[str, str]] = {}
 
         # Parse-result cache keyed by file path. Stores (mtime, parsed_dict).
         # Entries are reused only when mtime matches, so any file write
@@ -90,6 +98,105 @@ class FennScanner:
         if extra_dirs:
             for d in extra_dirs:
                 self._add_dir(d)
+
+        self._load_overrides()
+
+    def _load_overrides(self) -> None:
+        """Load persisted display-name overrides from disk."""
+        self._overrides = {}
+        try:
+            raw = self._overrides_path.read_text(encoding="utf-8")
+        except OSError:
+            return
+
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            return
+
+        if not isinstance(payload, dict):
+            return
+
+        cleaned: dict[str, dict[str, str]] = {}
+        for sid, data in payload.items():
+            if not isinstance(sid, str) or not isinstance(data, dict):
+                continue
+            display_name = data.get("display_name")
+            if isinstance(display_name, str) and display_name.strip():
+                cleaned[sid] = {"display_name": display_name.strip()}
+        self._overrides = cleaned
+
+    def _save_overrides(self) -> None:
+        """Persist display-name overrides atomically."""
+        self._overrides_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self._overrides_path.with_suffix(
+            self._overrides_path.suffix + ".tmp"
+        )
+        tmp_path.write_text(
+            json.dumps(self._overrides, ensure_ascii=True, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        os.replace(tmp_path, self._overrides_path)
+
+    def _display_name_for(self, session_id: str) -> str | None:
+        data = self._overrides.get(session_id, {})
+        display_name = data.get("display_name")
+        return display_name if display_name else None
+
+    def _with_display_name(self, session: SessionData) -> SessionData:
+        """Return a copy of a session dict with the current display-name override."""
+        return cast(
+            SessionData,
+            {
+                **session,
+                "display_name": self._display_name_for(session["session_id"]),
+            },
+        )
+
+    @staticmethod
+    def _normalize_display_name(display_name: str) -> str:
+        name = display_name.strip()
+        if not name:
+            raise ValueError("display_name must not be empty")
+        if len(name) > _MAX_DISPLAY_NAME_LENGTH:
+            raise ValueError(
+                f"display_name must be <= {_MAX_DISPLAY_NAME_LENGTH} characters"
+            )
+        return name
+
+    def rename_session(self, project: str, session_id: str, display_name: str) -> bool:
+        """Persist a custom display name for an existing session."""
+        name = self._normalize_display_name(display_name)
+        if self.get_session(project, session_id) is None:
+            return False
+
+        self._overrides[session_id] = {"display_name": name}
+        self._save_overrides()
+        return True
+
+    def delete_session(self, project: str, session_id: str) -> bool:
+        """Delete an existing session file and remove any related overrides/cache."""
+        session = self.get_session(project, session_id)
+        if session is None:
+            return False
+
+        path = Path(session["file_path"]).resolve()
+        if not any(path.is_relative_to(base) for base in self._dirs):
+            raise ValueError("session path is outside configured scan directories")
+
+        try:
+            path.unlink()
+        except OSError:
+            return False
+
+        self._parse_cache.pop(str(path), None)
+        self._files_cache = None
+
+        if session_id in self._overrides:
+            self._overrides.pop(session_id, None)
+            self._save_overrides()
+
+        return True
 
     def add_dirs(self, dirs: list[str]) -> None:
         for d in dirs:
@@ -216,6 +323,7 @@ class FennScanner:
 
         return SessionData(
             session_id=root.get("session_id", path.stem),
+            display_name=None,
             project=root.get("project", path.parent.name),
             started=root.get("started", ""),
             ended=ended,
@@ -250,7 +358,7 @@ class FennScanner:
         for path in self.find_fn_files():
             parsed = self.parse_fn_file(path)
             if parsed:
-                sessions.append(parsed)
+                sessions.append(self._with_display_name(parsed))
         return sessions
 
     @staticmethod
@@ -334,6 +442,7 @@ class FennScanner:
                 and parsed["project"] == project_name
                 and parsed["session_id"] == session_id
             ):
+                parsed = self._with_display_name(parsed)
                 overview = self.get_overview()
                 return cast(
                     SessionPagePayload,

--- a/fenn/dashboard/static/app.js
+++ b/fenn/dashboard/static/app.js
@@ -3,6 +3,69 @@
 (function () {
   "use strict";
 
+  function getCsrfToken() {
+    const meta = document.querySelector("meta[name='csrf-token']");
+    return meta?.getAttribute("content") || "";
+  }
+
+  function postJson(url, payload) {
+    return fetch(url, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": getCsrfToken(),
+      },
+      body: JSON.stringify(payload || {}),
+    });
+  }
+
+  function updateSearchableRow(row) {
+    if (!row) return;
+    const parts = [];
+    row.querySelectorAll("td[data-searchable]").forEach((cell) => {
+      const val = cell.getAttribute("data-searchable");
+      if (val) parts.push(val);
+    });
+    if (parts.length > 0) {
+      row.setAttribute("data-searchable", parts.join(" "));
+    }
+  }
+
+  function applyDisplayName(project, sessionId, displayName) {
+    const shown = displayName && displayName.trim() ? displayName.trim() : "—";
+    document
+      .querySelectorAll(`[data-project='${CSS.escape(project)}'][data-session='${CSS.escape(sessionId)}']`)
+      .forEach((node) => {
+        const nameEl = node.querySelector(".session-display-name");
+        if (nameEl) {
+          nameEl.textContent = shown;
+        }
+        if (node.matches("tr")) {
+          const nameCell = node.querySelector("td[data-searchable-name]");
+          if (nameCell) {
+            nameCell.setAttribute("data-searchable", displayName || "");
+          }
+          updateSearchableRow(node);
+        }
+      });
+
+    document.querySelectorAll(".session-rename-btn").forEach((btn) => {
+      if (btn.dataset.project === project && btn.dataset.session === sessionId) {
+        btn.dataset.currentName = displayName || "";
+      }
+    });
+
+    const headerTag = document.getElementById("session-display-name-header");
+    if (headerTag && headerTag.closest("[data-session]") === null) {
+      headerTag.textContent = displayName || "";
+    }
+    const subtitle = document.getElementById("session-display-name-subtitle");
+    if (subtitle && subtitle.querySelector(".session-display-name")) {
+      subtitle.querySelector(".session-display-name").textContent = shown;
+    }
+  }
+
   // ── Log viewer filters ─────────────────────────────────────────────────── //
 
   const levelState = { info: true, warning: true, exception: true };
@@ -147,6 +210,116 @@
     });
   });
   }
+
+  // ── Session rename/delete actions ────────────────────────────────────── //
+
+  document.querySelectorAll(".session-rename-btn").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      const project = btn.dataset.project;
+      const sessionId = btn.dataset.session;
+      if (!project || !sessionId) return;
+
+      const current = btn.dataset.currentName || "";
+      const next = window.prompt(
+        "Enter a custom session name (max 200 characters):",
+        current
+      );
+      if (next === null) return;
+
+      try {
+        const resp = await postJson(
+          `/api/session/${encodeURIComponent(project)}/${encodeURIComponent(sessionId)}/rename`,
+          { display_name: next }
+        );
+        const body = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+          window.alert(body?.error?.message || "Rename failed");
+          return;
+        }
+        applyDisplayName(project, sessionId, body.display_name || "");
+      } catch (_err) {
+        window.alert("Rename failed");
+      }
+    });
+  });
+
+  const deleteDialog = document.getElementById("delete-session-dialog");
+  const deleteCancel = document.getElementById("delete-session-cancel");
+  const deleteConfirm = document.getElementById("delete-session-confirm");
+  const deleteLabel = document.getElementById("delete-session-label");
+  const pendingDelete = { project: "", sessionId: "" };
+
+  document.querySelectorAll(".delete-session-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      pendingDelete.project = btn.dataset.project || "";
+      pendingDelete.sessionId = btn.dataset.session || "";
+      if (!pendingDelete.project || !pendingDelete.sessionId) return;
+
+      if (deleteLabel) {
+        deleteLabel.textContent = `${pendingDelete.project}/${pendingDelete.sessionId}`;
+      }
+
+      if (deleteDialog && typeof deleteDialog.showModal === "function") {
+        deleteDialog.showModal();
+      } else {
+        const ok = window.confirm(
+          `Delete ${pendingDelete.project}/${pendingDelete.sessionId}? This permanently removes the .fn file.`
+        );
+        if (ok && deleteConfirm) {
+          deleteConfirm.click();
+        }
+      }
+    });
+  });
+
+  deleteCancel?.addEventListener("click", () => {
+    deleteDialog?.close();
+  });
+
+  deleteDialog?.addEventListener("click", (e) => {
+    if (e.target === deleteDialog) deleteDialog.close();
+  });
+
+  deleteConfirm?.addEventListener("click", async () => {
+    if (!pendingDelete.project || !pendingDelete.sessionId) {
+      deleteDialog?.close();
+      return;
+    }
+
+    try {
+      const resp = await postJson(
+        `/api/session/${encodeURIComponent(pendingDelete.project)}/${encodeURIComponent(pendingDelete.sessionId)}/delete`,
+        {}
+      );
+      const body = await resp.json().catch(() => ({}));
+      if (!resp.ok) {
+        window.alert(body?.error?.message || "Delete failed");
+        return;
+      }
+
+      const rows = document.querySelectorAll(
+        `tr[data-project='${CSS.escape(pendingDelete.project)}'][data-session='${CSS.escape(pendingDelete.sessionId)}']`
+      );
+      if (rows.length > 0) {
+        rows.forEach((row) => row.remove());
+      }
+
+      const sessionStatusEl = document.getElementById("session-status");
+      if (
+        sessionStatusEl &&
+        sessionStatusEl.dataset.project === pendingDelete.project &&
+        sessionStatusEl.dataset.session === pendingDelete.sessionId
+      ) {
+        location.href = `/project/${encodeURIComponent(pendingDelete.project)}`;
+        return;
+      }
+    } catch (_err) {
+      window.alert("Delete failed");
+      return;
+    } finally {
+      deleteDialog?.close();
+    }
+  });
 
   // ── Logout confirmation dialog ─────────────────────────────────────────── //
 

--- a/fenn/dashboard/templates/base.html
+++ b/fenn/dashboard/templates/base.html
@@ -10,6 +10,7 @@
         href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@500;600;700;800&family=DM+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='images/icon.png') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <meta name="csrf-token" content="{{ csrf_token() }}">
 </head>
 <body>
 <div class="layout">
@@ -86,6 +87,20 @@
         <div class="confirm-actions">
           <button type="button" class="btn-ghost" id="logout-cancel">Cancel</button>
           <button type="button" class="btn-danger" id="logout-confirm">Disconnect</button>
+        </div>
+      </dialog>
+
+      <dialog id="delete-session-dialog"
+              class="confirm-dialog"
+              aria-labelledby="delete-session-dialog-title">
+        <h2 class="confirm-title" id="delete-session-dialog-title">Delete Session?</h2>
+        <p class="confirm-body">
+          This permanently removes the <span id="delete-session-label"></span> log file from disk.
+          This action cannot be undone.
+        </p>
+        <div class="confirm-actions">
+          <button type="button" class="btn-ghost" id="delete-session-cancel">Cancel</button>
+          <button type="button" class="btn-danger" id="delete-session-confirm">Delete</button>
         </div>
       </dialog>
       {% endif %}

--- a/fenn/dashboard/templates/index.html
+++ b/fenn/dashboard/templates/index.html
@@ -93,23 +93,33 @@
         <tr>
           <th>Project</th>
           <th>Session ID</th>
+          <th>Name</th>
           <th>Started</th>
           <th>Duration</th>
           <th>Status</th>
           <th>Entries</th>
           <th>Warnings</th>
           <th>Exceptions</th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
         {% for s in recent_sessions %}
-        <tr data-searchable="{{ s.project }} {{ s.session_id }}" data-session="{{ s.session_id }}">
+        <tr data-searchable="{{ s.project }} {{ s.session_id }} {{ s.display_name or '' }}" data-project="{{ s.project }}" data-session="{{ s.session_id }}">
           <td data-searchable="{{ s.project }}">
             <a href="/project/{{ s.project | urlencode }}">{{ s.project }}</a>
           </td>
           <td data-searchable="{{ s.session_id }}">
             <a href="/session/{{ s.project | urlencode }}/{{ s.session_id | urlencode }}"
                class="td-mono">{{ s.session_id | short_id }}…</a>
+          </td>
+          <td class="td-mono" data-searchable="{{ s.display_name or '' }}" data-searchable-name>
+            <span class="session-display-name">{{ s.display_name or '—' }}</span>
+            <button type="button"
+                    class="btn btn-sm session-rename-btn"
+                    data-project="{{ s.project }}"
+                    data-session="{{ s.session_id }}"
+                    data-current-name="{{ s.display_name or '' }}">Rename</button>
           </td>
           <td class="td-mono" data-searchable="{{ s.started }}">{{ s.started }}</td>
           <td class="td-mono" data-searchable="{{ s.duration_s | duration }} ">{{ s.duration_s | duration }}</td>
@@ -132,6 +142,12 @@
           <td class="td-mono {% if s.exception_count > 0 %}has-error{% endif %}"
               style="{% if s.exception_count > 0 %}color:var(--error){% endif %}">
             {{ s.exception_count if s.exception_count else '—' }}
+          </td>
+          <td>
+            <button type="button"
+                    class="btn btn-sm delete-session-btn"
+                    data-project="{{ s.project }}"
+                    data-session="{{ s.session_id }}">Delete</button>
           </td>
         </tr>
         {% endfor %}

--- a/fenn/dashboard/templates/project.html
+++ b/fenn/dashboard/templates/project.html
@@ -51,6 +51,7 @@
       <thead>
         <tr>
           <th>Session ID</th>
+          <th>Name</th>
           <th>Started</th>
           <th>Duration</th>
           <th>Status</th>
@@ -58,15 +59,24 @@
           <th>Warnings</th>
           <th>Exceptions</th>
           <th>Size</th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
         {% for s in sessions %}
-        <tr data-searchable="{{ s.session_id }} {{ s.started }}">
+        <tr data-searchable="{{ s.session_id }} {{ s.display_name or '' }} {{ s.started }}" data-project="{{ s.project }}" data-session="{{ s.session_id }}">
           <td>
             <a href="/session/{{ s.project | urlencode }}/{{ s.session_id | urlencode }}"
                class="td-mono"
                title="{{ s.session_id }}">{{ s.session_id }}</a>
+          </td>
+          <td class="td-mono" data-searchable="{{ s.display_name or '' }}" data-searchable-name>
+            <span class="session-display-name">{{ s.display_name or '—' }}</span>
+            <button type="button"
+                    class="btn btn-sm session-rename-btn"
+                    data-project="{{ s.project }}"
+                    data-session="{{ s.session_id }}"
+                    data-current-name="{{ s.display_name or '' }}">Rename</button>
           </td>
           <td class="td-mono">{{ s.started }}</td>
           <td class="td-mono">{{ s.duration_s | duration }}</td>
@@ -91,6 +101,12 @@
             {{ s.exception_count if s.exception_count else '—' }}
           </td>
           <td class="td-mono">{{ s.file_size | filesize }}</td>
+          <td>
+            <button type="button"
+                    class="btn btn-sm delete-session-btn"
+                    data-project="{{ s.project }}"
+                    data-session="{{ s.session_id }}">Delete</button>
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/fenn/dashboard/templates/session.html
+++ b/fenn/dashboard/templates/session.html
@@ -21,6 +21,7 @@
 
 <!-- Header -->
 <div class="page-header">
+  <span class="page-tag" id="session-display-name-header">{{ display_name or '' }}</span>
   <h1 class="page-title" style="font-family:var(--font-mono); font-size:18px; letter-spacing:0;">
     {{ session_id }}
     {% if status == 'crashed' %}
@@ -35,6 +36,18 @@
     <span class="badge badge-completed" style="font-size:12px; margin-left:8px; vertical-align:middle;">completed</span>
     {% endif %}
   </h1>
+  <p class="page-subtitle" id="session-display-name-subtitle">
+    Display name: <span class="session-display-name">{{ display_name or '—' }}</span>
+    <button type="button"
+            class="btn btn-sm session-rename-btn"
+            data-project="{{ project }}"
+            data-session="{{ session_id }}"
+            data-current-name="{{ display_name or '' }}">Rename</button>
+    <button type="button"
+            class="btn btn-sm delete-session-btn"
+            data-project="{{ project }}"
+            data-session="{{ session_id }}">Delete</button>
+  </p>
 </div>
 
 <!-- Meta row -->

--- a/fenn/dashboard/types.py
+++ b/fenn/dashboard/types.py
@@ -30,6 +30,7 @@ class SessionData(TypedDict):
     """Complete parsed session data from _parse_uncached()."""
 
     session_id: str
+    display_name: str | None
     project: str
     started: str
     ended: str | None
@@ -52,6 +53,7 @@ class SessionListItem(TypedDict):
     """Lightweight session for paginated listings (entries & config stripped)."""
 
     session_id: str
+    display_name: str | None
     project: str
     started: str
     ended: str | None
@@ -107,6 +109,7 @@ class SessionPagePayload(TypedDict):
     """GET /api/project/<name>/session/<id> — session detail response."""
 
     session_id: str
+    display_name: str | None
     project: str
     started: str
     ended: str | None

--- a/tests/unit/dashboard/test_api.py
+++ b/tests/unit/dashboard/test_api.py
@@ -1,5 +1,7 @@
 """Unit tests for the /api/sessions endpoint (Pick 3)."""
 
+import re
+
 import pytest
 
 from fenn.dashboard.app import app
@@ -28,8 +30,18 @@ def _write(path, content):
     return path
 
 
+def _extract_csrf_token(html: str) -> str | None:
+    meta = re.search(r'<meta name="csrf-token" content="([^"]+)"', html)
+    if meta:
+        return meta.group(1)
+    hidden = re.search(r'name="csrf_token" value="([^"]+)"', html)
+    if hidden:
+        return hidden.group(1)
+    return None
+
+
 @pytest.fixture()
-def scanner_with_sessions(tmp_path):
+def scanner_with_sessions(tmp_path, monkeypatch):
     """Return a FennScanner loaded with a small set of known sessions."""
     sessions = [
         dict(
@@ -60,6 +72,9 @@ def scanner_with_sessions(tmp_path):
     for s in sessions:
         _write(tmp_path / f"{s['sid']}.fn", _FN_TMPL.format(**s))
 
+    monkeypatch.setenv(
+        "FENN_DASHBOARD_OVERRIDES_PATH", str(tmp_path / "dashboard_overrides.json")
+    )
     scanner = FennScanner(extra_dirs=[str(tmp_path)])
     return scanner
 
@@ -75,6 +90,19 @@ def client(scanner_with_sessions):
     with app.test_client() as c:
         with c.session_transaction() as sess:
             sess["user"] = {"email": "test@example.com"}  # любой dict
+        yield c
+    app_module.scanner = original
+
+
+@pytest.fixture()
+def client_no_auth(scanner_with_sessions):
+    """Flask test client using scanner fixture, but without logged-in user."""
+    import fenn.dashboard.app as app_module
+
+    original = app_module.scanner
+    app_module.scanner = scanner_with_sessions
+    app.config["TESTING"] = True
+    with app.test_client() as c:
         yield c
     app_module.scanner = original
 
@@ -275,6 +303,98 @@ class TestExistingEndpoints:
         data = resp.get_json()
         assert "projects" in data
         assert "total_sessions" in data
+
+
+class TestSessionMutationRoutes:
+    """Rename/delete routes should enforce validation, CSRF, and auth."""
+
+    def test_rename_session_success(self, client):
+        token = _extract_csrf_token(client.get("/").get_data(as_text=True))
+        assert token
+
+        resp = client.post(
+            "/api/session/alpha/a1/rename",
+            json={"display_name": "Alpha baseline"},
+            headers={"X-CSRFToken": token},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["display_name"] == "Alpha baseline"
+
+        check = client.get("/api/session/alpha/a1")
+        assert check.status_code == 200
+        assert check.get_json()["display_name"] == "Alpha baseline"
+
+    def test_rename_empty_name_returns_400(self, client):
+        token = _extract_csrf_token(client.get("/").get_data(as_text=True))
+        assert token
+
+        resp = client.post(
+            "/api/session/alpha/a1/rename",
+            json={"display_name": "   "},
+            headers={"X-CSRFToken": token},
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["error"]["code"] == "invalid_param"
+        assert body["error"]["param"] == "display_name"
+
+    def test_delete_session_success(self, client):
+        token = _extract_csrf_token(client.get("/").get_data(as_text=True))
+        assert token
+
+        resp = client.post(
+            "/api/session/alpha/a2/delete",
+            json={},
+            headers={"X-CSRFToken": token},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["deleted"] is True
+
+        check = client.get("/api/session/alpha/a2")
+        assert check.status_code == 404
+
+    def test_delete_unknown_session_returns_404(self, client):
+        token = _extract_csrf_token(client.get("/").get_data(as_text=True))
+        assert token
+
+        resp = client.post(
+            "/api/session/alpha/nope/delete",
+            json={},
+            headers={"X-CSRFToken": token},
+        )
+        assert resp.status_code == 404
+
+    def test_mutation_routes_without_auth_redirect_to_connect(self, client_no_auth):
+        token = _extract_csrf_token(
+            client_no_auth.get("/connect").get_data(as_text=True)
+        )
+        assert token
+
+        rename_resp = client_no_auth.post(
+            "/api/session/alpha/a1/rename",
+            json={"display_name": "x"},
+            headers={"X-CSRFToken": token},
+        )
+        delete_resp = client_no_auth.post(
+            "/api/session/alpha/a1/delete",
+            json={},
+            headers={"X-CSRFToken": token},
+        )
+
+        assert rename_resp.status_code == 302
+        assert "/connect" in rename_resp.headers.get("Location", "")
+        assert delete_resp.status_code == 302
+        assert "/connect" in delete_resp.headers.get("Location", "")
+
+    def test_mutation_routes_without_csrf_return_400(self, client):
+        rename_resp = client.post(
+            "/api/session/alpha/a1/rename",
+            json={"display_name": "x"},
+        )
+        delete_resp = client.post("/api/session/alpha/a1/delete", json={})
+
+        assert rename_resp.status_code == 400
+        assert delete_resp.status_code == 400
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/dashboard/test_scanner.py
+++ b/tests/unit/dashboard/test_scanner.py
@@ -1,5 +1,6 @@
 """Unit tests for FennScanner.get_all_sessions() and get_session()."""
 
+import json
 import time
 from pathlib import Path
 
@@ -62,6 +63,18 @@ class TestGetAllSessions:
 
         assert result == []
 
+    def test_default_display_name_is_none(self, tmp_path, monkeypatch):
+        """Session payloads expose display_name and default it to None."""
+        monkeypatch.setenv(
+            "FENN_DASHBOARD_OVERRIDES_PATH", str(tmp_path / "dashboard_overrides.json")
+        )
+        _write(tmp_path / "s1.fn", _SAMPLE_FN.format(project="proj", sid="s1"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        result = scanner.get_all_sessions()
+
+        assert result[0]["display_name"] is None
+
 
 # ---------------------------------------------------------------------------
 # get_session — additional edge cases beyond test_scanner_cache.py
@@ -90,3 +103,78 @@ class TestGetSessionEdgeCases:
 
         assert result is not None
         assert result["session_id"] == "sess_y"
+
+
+class TestSessionMutations:
+    def test_rename_session_persists_across_scanner_instances(
+        self, tmp_path, monkeypatch
+    ):
+        overrides_path = tmp_path / "dashboard_overrides.json"
+        monkeypatch.setenv("FENN_DASHBOARD_OVERRIDES_PATH", str(overrides_path))
+        _write(tmp_path / "s1.fn", _SAMPLE_FN.format(project="proj", sid="s1"))
+
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+        assert scanner.rename_session("proj", "s1", "  Friendly Name  ") is True
+
+        s1 = scanner.get_session("proj", "s1")
+        assert s1 is not None
+        assert s1["display_name"] == "Friendly Name"
+
+        scanner_reloaded = FennScanner(extra_dirs=[str(tmp_path)])
+        s1_reloaded = scanner_reloaded.get_session("proj", "s1")
+        assert s1_reloaded is not None
+        assert s1_reloaded["display_name"] == "Friendly Name"
+
+    def test_rename_session_rejects_invalid_display_name(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "FENN_DASHBOARD_OVERRIDES_PATH", str(tmp_path / "dashboard_overrides.json")
+        )
+        _write(tmp_path / "s1.fn", _SAMPLE_FN.format(project="proj", sid="s1"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        try:
+            scanner.rename_session("proj", "s1", "   ")
+            assert False, "expected ValueError for blank display_name"
+        except ValueError:
+            assert True
+
+    def test_rename_session_returns_false_for_unknown_session(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv(
+            "FENN_DASHBOARD_OVERRIDES_PATH", str(tmp_path / "dashboard_overrides.json")
+        )
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        assert scanner.rename_session("proj", "missing", "Name") is False
+
+    def test_delete_session_removes_file_and_clears_cache_and_override(
+        self, tmp_path, monkeypatch
+    ):
+        overrides_path = tmp_path / "dashboard_overrides.json"
+        monkeypatch.setenv("FENN_DASHBOARD_OVERRIDES_PATH", str(overrides_path))
+        path = _write(tmp_path / "s1.fn", _SAMPLE_FN.format(project="proj", sid="s1"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        scanner.parse_fn_file(path)
+        assert str(path) in scanner._parse_cache
+        assert scanner.rename_session("proj", "s1", "Name") is True
+
+        assert scanner.delete_session("proj", "s1") is True
+        assert not path.exists()
+        assert str(path) not in scanner._parse_cache
+        assert scanner._files_cache is None
+        assert scanner.get_session("proj", "s1") is None
+
+        payload = json.loads(overrides_path.read_text(encoding="utf-8"))
+        assert "s1" not in payload
+
+    def test_delete_session_returns_false_for_unknown_session(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv(
+            "FENN_DASHBOARD_OVERRIDES_PATH", str(tmp_path / "dashboard_overrides.json")
+        )
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        assert scanner.delete_session("proj", "missing") is False


### PR DESCRIPTION
Fixes: #231 

## Changes

* Added support for persistent session display names using a lightweight JSON-based override store (`dashboard_overrides.json`), without modifying the underlying `.fn` log files.
* Introduced `rename_session()` and `delete_session()` in `FennScanner`, including validation, persistence, cache invalidation, and cleanup of associated overrides.
* Added `display_name` to all dashboard session payloads (`SessionData`, `SessionListItem`, and `SessionPagePayload`).
* Added new authenticated, CSRF-protected API endpoints:

  * `POST /api/session/<project>/<session>/rename`
  * `POST /api/session/<project>/<session>/delete`
* Updated the dashboard UI to:

  * Display custom session names across overview, project, and session pages.
  * Support inline session renaming.
  * Add delete actions with a confirmation dialog.
  * Make display names searchable using the existing client-side search.

## Notes

* Session display names are stored separately from the underlying `.fn` files, allowing sessions to be renamed without affecting experiment data or session identifiers.
* Deleting a session permanently removes the corresponding `.fn` file from disk and also removes any associated display name override.
* Display name validation enforces trimmed, non-empty values with a maximum length of 200 characters.