### PR TITLE
fix: reshape binary validation labels

### DIFF
--- a/fenn/nn/trainers/classification_trainer.py
+++ b/fenn/nn/trainers/classification_trainer.py
@@ -233,7 +233,11 @@ class ClassificationTrainer(Trainer):
                         labels = labels.to(self._device)
 
                         outputs = self._model(data)
-                        val_batch_loss = self._loss_fn(outputs, labels)
+                        loss_labels = labels
+                        if self._num_classes == 2:
+                            loss_labels = labels.view(-1, 1).float()
+
+                        val_batch_loss = self._loss_fn(outputs, loss_labels)
 
                         val_total_loss += float(val_batch_loss.item())
                         val_n_batches += 1
@@ -246,7 +250,10 @@ class ClassificationTrainer(Trainer):
                             preds = torch.argmax(outputs, dim=1)
 
                         val_predictions.extend(preds.cpu().tolist())
-                        val_labels.extend(labels.cpu().tolist())
+                        if self._num_classes == 2:
+                            val_labels.extend(labels.cpu().view(-1).tolist())
+                        else:
+                            val_labels.extend(labels.cpu().tolist())
 
                 if val_n_batches == 0:
                     raise ValueError("val_loader produced 0 batches; cannot validate.")

--- a/tests/unit/nn/test_classification_trainer.py
+++ b/tests/unit/nn/test_classification_trainer.py
@@ -179,6 +179,14 @@ class TestClassificationTrainerFit:
         _fit(trainer, _make_dataloader(n_batches=1, n_classes=2), epochs=1)
         assert trainer._state.train_loss is not None
 
+    def test_binary_validation_label_reshaped(self):
+        trainer = _make_trainer(num_classes=2)
+        trainer._loss_fn = nn.BCEWithLogitsLoss()
+        trainer._model = nn.Linear(4, 1)
+        loader = _make_dataloader(n_batches=1, n_classes=2)
+        _fit(trainer, loader, epochs=1, val_loader=loader)
+        assert trainer._state.val_loss is not None
+
     def test_multiple_epochs(self):
         trainer = _make_trainer(num_classes=3)
         _fit(trainer, _make_dataloader(n_classes=3), epochs=3)

--- a/tests/unit/nn/test_mlp.py
+++ b/tests/unit/nn/test_mlp.py
@@ -153,17 +153,6 @@ class TestMLPClassifierBinary:
         preds = clf.predict(X)
         assert set(preds).issubset({"cat", "dog"})
 
-    @pytest.mark.xfail(
-        reason=(
-            "Pre-existing bug in ClassificationTrainer.fit(): the validation branch "
-            "does not reshape labels to (-1, 1) for binary classification the way the "
-            "training branch does, so BCEWithLogitsLoss raises a shape mismatch as soon "
-            "as a val_loader is used with num_classes == 2. Flagged upstream; not fixed "
-            "here since this module must not contain training-loop code. "
-            "See ClassificationTrainer.fit, the '--- VALIDATION ---' block."
-        ),
-        strict=True,
-    )
     def test_early_stopping_runs(self):
         X, y = _make_classification_data(n_samples=60, n_classes=2)
         clf = MLPClassifier(


### PR DESCRIPTION
Fixes #250

## Summary
- reshape binary classification labels before validation loss calculation so BCEWithLogitsLoss receives the expected shape
- keep validation accuracy labels flat after preparing loss labels
- promote the MLP binary early-stopping regression test from xfail to an active test

## Tests
- `UV_FROZEN=1 uv run --frozen --python 3.12 nox -s unit` (605 passed, 1 skipped)
- `uv run --frozen --python 3.12 ruff check fenn`
- `uv run --frozen --python 3.12 ruff format --check fenn tests/unit/nn/test_classification_trainer.py tests/unit/nn/test_mlp.py`