### PR TITLE
update the ci and test for temp

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,13 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
@@ -69,6 +70,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
@@ -84,4 +86,3 @@ jobs:
           
       - name: Run pre-commit hook
         run: pre-commit run --all-files
-

--- a/tests/templates/test_temp_main.py
+++ b/tests/templates/test_temp_main.py
@@ -26,10 +26,12 @@ TEMPLATES_LIST = [
 def get_template_directories():
     if not os.path.exists(TEMPLATE_DIR):
         return []
+
     return [
         d
         for d in os.listdir(TEMPLATE_DIR)
-        if d not in [".git", ".gitignore", "__init__.py", "LICENSE"]
+        if os.path.isdir(os.path.join(TEMPLATE_DIR, d))
+        and d not in [".git", "__pycache__"]
     ]
 
 

--- a/tests/templates/test_temp_main.py
+++ b/tests/templates/test_temp_main.py
@@ -1,0 +1,77 @@
+import os
+import subprocess
+import sys
+
+import pytest
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+TEMPLATE_DIR = os.path.abspath(os.path.join(TEST_DIR, "..", "templates"))
+
+TEMPLATES_LIST = [
+    "chatbot",
+    "cnn",
+    "empty",
+    "lora-cls",
+    "lstm-cls",
+    "lstm-gen",
+    "mlp-binary",
+    "mlp-multiclass",
+    "mlp-regression",
+    "timm-cls",
+    "vae",
+    "yolo",
+]
+
+
+def get_template_directories():
+    if not os.path.exists(TEMPLATE_DIR):
+        return []
+    return [
+        d
+        for d in os.listdir(TEMPLATE_DIR)
+        if d not in [".git", ".gitignore", "__init__.py", "LICENSE"]
+    ]
+
+
+def test_templates_dir_exists():
+    assert os.path.exists(TEMPLATE_DIR), (
+        f"Templates directory not found at {TEMPLATE_DIR}. Did you pull the submodule?"
+    )
+
+
+@pytest.mark.parametrize("template_name", get_template_directories())
+def test_template_structure_and_execution(template_name):
+    assert template_name in TEMPLATES_LIST, (
+        f"Unexpected directory found in templates: {template_name}"
+    )
+
+    template_path = os.path.join(TEMPLATE_DIR, template_name)
+    main_path = os.path.join(template_path, "main.py")
+    requirement_path = os.path.join(template_path, "requirements.txt")
+
+    assert os.path.exists(main_path), f"Missing main.py in {template_name}"
+    assert os.path.exists(requirement_path), (
+        f"Missing requirements.txt in {template_name}"
+    )
+
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "-r", requirement_path],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            [sys.executable, main_path],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError as e:
+        raise AssertionError(f"Template '{template_name}' execution failed: {e}")
+    finally:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "uninstall", "-y", "-r", requirement_path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )


### PR DESCRIPTION
Added: test_temp_main.py — tests that each template's requirements.txt installs cleanly and main.py runs without errors.
Updated: ci.yaml — adjusted the workflow so these new template tests run without conflicting with the existing test/pre-commit jobs.
Still needed: the templates submodule pointer needs to be bumped to the latest commit I wasn't able to resolve a submodule merge conflict locally. Once it's updated, remaining failures should mostly be a few templates missing requirements.txt (e.g. chatbot/).