### PR TITLE
feat(dashboard)[#254]: soft delete(archive) support for log sessions

### DIFF
--- a/fenn/dashboard/app.py
+++ b/fenn/dashboard/app.py
@@ -64,6 +64,12 @@ csrf = CSRFProtect(app)
 scanner = FennScanner()
 
 
+class _ApiBadRequest(Exception):
+    def __init__(self, message: str, param: str | None = None) -> None:
+        self.message = message
+        self.param = param
+
+
 @app.context_processor
 def _inject_current_user() -> dict[str, Any]:
     return {"current_user": dashboard_auth.current_user()}
@@ -81,6 +87,19 @@ _STORED_TOKEN_OFFLINE_MESSAGE = (
     "Could not reach https://pyfenn.com to verify your saved token. "
     "Using cached identity — the dashboard will revalidate next launch."
 )
+
+_MAX_LIMIT = 200
+_DEFAULT_LIMIT = 20
+
+
+def _api_error(
+    code: str, message: str, param: str | None = None
+) -> tuple[Response, int]:
+    """Standard 400 envelope so clients can branch on `error.code`."""
+    body = {"error": {"code": code, "message": message}}
+    if param is not None:
+        body["error"]["param"] = param
+    return jsonify(body), 400
 
 
 def _try_stored_session() -> werkzeug.wrappers.response.Response | None:
@@ -118,6 +137,20 @@ def _try_stored_session() -> werkzeug.wrappers.response.Response | None:
     # sees the freshly-loaded identity instead of the prior None.
     g.pop("current_user", None)
     return None
+
+
+def _parse_int_arg(
+    name: str, raw: str | None, default: int, min_v: int, max_v: int
+) -> int:
+    if raw is None or raw == "":
+        return default
+    try:
+        v = int(raw)
+    except ValueError:
+        raise _ApiBadRequest(f"{name} must be an integer", name)
+    if v < min_v or v > max_v:
+        raise _ApiBadRequest(f"{name} must be between {min_v} and {max_v}", name)
+    return v
 
 
 @app.before_request
@@ -174,12 +207,22 @@ def short_id_filter(session_id: str) -> str:
 
 @app.route("/")
 def index() -> str:
-    return render_template("index.html", **scanner.get_overview())
+    include_archived = (request.args.get("include_archived") or "").lower() == "true"
+    return render_template(
+        "index.html",
+        **scanner.get_overview(include_archived=include_archived),
+        include_archived=include_archived,
+    )
 
 
 @app.route("/project/<project_name>")
 def project(project_name: str) -> str:
-    return render_template("project.html", **scanner.get_project(project_name))
+    include_archived = (request.args.get("include_archived") or "").lower() == "true"
+    return render_template(
+        "project.html",
+        **scanner.get_project(project_name, include_archived=include_archived),
+        include_archived=include_archived,
+    )
 
 
 @app.route("/session/<project_name>/<session_id>", endpoint="session")
@@ -192,7 +235,8 @@ def session_view(project_name: str, session_id: str) -> str:
 
 @app.route("/api/overview")
 def api_overview() -> Response:
-    return jsonify(scanner.get_overview())
+    include_archived = (request.args.get("include_archived") or "").lower() == "true"
+    return jsonify(scanner.get_overview(include_archived=include_archived))
 
 
 @app.route("/api/session/<project_name>/<session_id>")
@@ -246,40 +290,24 @@ def api_session_delete(
     return jsonify({"deleted": True})
 
 
-# Pagination / filtering limits. 200 is large enough for any plausible UI
-# without letting a client ask for "everything" by accident.
-_MAX_LIMIT = 200
-_DEFAULT_LIMIT = 20
+@app.route("/api/session/<project_name>/<session_id>/archive", methods=["POST"])
+def api_session_archive(
+    project_name: str, session_id: str
+) -> tuple[Response, int] | Response:
+    ok = scanner.archive_session(project_name, session_id)
+    if not ok:
+        abort(404)
+    return jsonify({"archived": True})
 
 
-def _api_error(
-    code: str, message: str, param: str | None = None
-) -> tuple[Response, int]:
-    """Standard 400 envelope so clients can branch on `error.code`."""
-    body = {"error": {"code": code, "message": message}}
-    if param is not None:
-        body["error"]["param"] = param
-    return jsonify(body), 400
-
-
-class _ApiBadRequest(Exception):
-    def __init__(self, message: str, param: str | None = None) -> None:
-        self.message = message
-        self.param = param
-
-
-def _parse_int_arg(
-    name: str, raw: str | None, default: int, min_v: int, max_v: int
-) -> int:
-    if raw is None or raw == "":
-        return default
-    try:
-        v = int(raw)
-    except ValueError:
-        raise _ApiBadRequest(f"{name} must be an integer", name)
-    if v < min_v or v > max_v:
-        raise _ApiBadRequest(f"{name} must be between {min_v} and {max_v}", name)
-    return v
+@app.route("/api/session/<project_name>/<session_id>/restore", methods=["POST"])
+def api_session_restore(
+    project_name: str, session_id: str
+) -> tuple[Response, int] | Response:
+    ok = scanner.restore_session(project_name, session_id)
+    if not ok:
+        abort(404)
+    return jsonify({"archived": False})
 
 
 @app.route("/api/sessions")
@@ -292,11 +320,15 @@ def api_sessions() -> tuple[Response, int] | Response:
         limit (1..200, default 20),
         offset (>=0, default 0),
         sort (field, optionally ``-`` prefixed for descending),
-        started_after, started_before (timestamps formatted as ``YYYY-MM-DD HH:MM:SS``).
+        started_after, started_before (timestamps formatted as ``YYYY-MM-DD HH:MM:SS``),
+        include_archived (true/false, default false)
     """
     try:
         project_name = request.args.get("project") or None
         status = request.args.get("status") or None
+        include_archived = (
+            request.args.get("include_archived") or ""
+        ).lower() == "true"
         sort = request.args.get("sort") or "-started"
         limit = _parse_int_arg(
             "limit", request.args.get("limit"), _DEFAULT_LIMIT, 1, _MAX_LIMIT
@@ -333,6 +365,7 @@ def api_sessions() -> tuple[Response, int] | Response:
             result = scanner.list_sessions(
                 project=project_name,
                 status=status,
+                include_archived=include_archived,
                 started_after=started_after,
                 started_before=started_before,
                 limit=limit,

--- a/fenn/dashboard/scanner.py
+++ b/fenn/dashboard/scanner.py
@@ -73,7 +73,7 @@ class FennScanner:
         self._overrides_path = Path(
             os.environ.get("FENN_DASHBOARD_OVERRIDES_PATH", _DEFAULT_OVERRIDES_PATH)
         ).expanduser()
-        self._overrides: dict[str, dict[str, str]] = {}
+        self._overrides: dict[str, dict[str, Any]] = {}
 
         # Parse-result cache keyed by file path. Stores (mtime, parsed_dict).
         # Entries are reused only when mtime matches, so any file write
@@ -102,7 +102,7 @@ class FennScanner:
         self._load_overrides()
 
     def _load_overrides(self) -> None:
-        """Load persisted display-name overrides from disk."""
+        """Load persisted session overrides from disk."""
         self._overrides = {}
         try:
             raw = self._overrides_path.read_text(encoding="utf-8")
@@ -117,13 +117,19 @@ class FennScanner:
         if not isinstance(payload, dict):
             return
 
-        cleaned: dict[str, dict[str, str]] = {}
+        cleaned: dict[str, dict[str, Any]] = {}
         for sid, data in payload.items():
             if not isinstance(sid, str) or not isinstance(data, dict):
                 continue
+            cleaned_data: dict[str, Any] = {}
             display_name = data.get("display_name")
             if isinstance(display_name, str) and display_name.strip():
-                cleaned[sid] = {"display_name": display_name.strip()}
+                cleaned_data["display_name"] = display_name.strip()
+            archived = data.get("archived")
+            if isinstance(archived, bool):
+                cleaned_data["archived"] = archived
+            if cleaned_data:
+                cleaned[sid] = cleaned_data
         self._overrides = cleaned
 
     def _save_overrides(self) -> None:
@@ -138,20 +144,50 @@ class FennScanner:
         )
         os.replace(tmp_path, self._overrides_path)
 
-    def _display_name_for(self, session_id: str) -> str | None:
+    def _overrides_for(self, session_id: str) -> tuple[str | None, bool]:
         data = self._overrides.get(session_id, {})
         display_name = data.get("display_name")
-        return display_name if display_name else None
+        archived = data.get("archived")
+        return (
+            display_name if isinstance(display_name, str) and display_name else None,
+            bool(archived),
+        )
 
-    def _with_display_name(self, session: SessionData) -> SessionData:
-        """Return a copy of a session dict with the current display-name override."""
+    def _with_overrides(self, session: SessionData) -> SessionData:
+        """Return a copy of a session dict with persisted overrides merged in."""
+        display_name, archived = self._overrides_for(session["session_id"])
         return cast(
             SessionData,
             {
                 **session,
-                "display_name": self._display_name_for(session["session_id"]),
+                "display_name": display_name,
+                "archived": archived,
             },
         )
+
+    def _upsert_override(
+        self,
+        session_id: str,
+        *,
+        display_name: str | None = None,
+        archived: bool | None = None,
+    ) -> None:
+        data = dict(self._overrides.get(session_id, {}))
+        if display_name is not None:
+            data["display_name"] = display_name
+        if archived is not None:
+            data["archived"] = archived
+
+        # Keep the file compact: omit false/default archived and empty names.
+        if not data.get("display_name"):
+            data.pop("display_name", None)
+        if data.get("archived") is not True:
+            data.pop("archived", None)
+
+        if data:
+            self._overrides[session_id] = data
+        else:
+            self._overrides.pop(session_id, None)
 
     @staticmethod
     def _normalize_display_name(display_name: str) -> str:
@@ -170,7 +206,23 @@ class FennScanner:
         if self.get_session(project, session_id) is None:
             return False
 
-        self._overrides[session_id] = {"display_name": name}
+        self._upsert_override(session_id, display_name=name)
+        self._save_overrides()
+        return True
+
+    def archive_session(self, project: str, session_id: str) -> bool:
+        """Soft delete a session by marking it archived in overrides."""
+        if self.get_session(project, session_id) is None:
+            return False
+        self._upsert_override(session_id, archived=True)
+        self._save_overrides()
+        return True
+
+    def restore_session(self, project: str, session_id: str) -> bool:
+        """Restore an archived session by clearing its archived override flag."""
+        if self.get_session(project, session_id) is None:
+            return False
+        self._upsert_override(session_id, archived=False)
         self._save_overrides()
         return True
 
@@ -324,6 +376,7 @@ class FennScanner:
         return SessionData(
             session_id=root.get("session_id", path.stem),
             display_name=None,
+            archived=False,
             project=root.get("project", path.parent.name),
             started=root.get("started", ""),
             ended=ended,
@@ -352,13 +405,16 @@ class FennScanner:
                 return cast(SessionData, {**parsed, "status": "crashed"})
         return parsed
 
-    def get_all_sessions(self) -> list[SessionData]:
+    def get_all_sessions(self, include_archived: bool = False) -> list[SessionData]:
         """Return all parsed sessions, newest first."""
         sessions: list[SessionData] = []
         for path in self.find_fn_files():
             parsed = self.parse_fn_file(path)
             if parsed:
-                sessions.append(self._with_display_name(parsed))
+                session = self._with_overrides(parsed)
+                if not include_archived and session["archived"]:
+                    continue
+                sessions.append(session)
         return sessions
 
     @staticmethod
@@ -389,9 +445,9 @@ class FennScanner:
             projects.values(), key=lambda project: project["last_active"], reverse=True
         )
 
-    def get_overview(self) -> OverviewPayload:
+    def get_overview(self, include_archived: bool = False) -> OverviewPayload:
         """Aggregate stats for the dashboard home page."""
-        sessions = self.get_all_sessions()
+        sessions = self.get_all_sessions(include_archived=include_archived)
         project_list = self._build_projects_list(sessions)
 
         return OverviewPayload(
@@ -406,9 +462,11 @@ class FennScanner:
             active_page="home",
         )
 
-    def get_project(self, project_name: str) -> ProjectPayload:
+    def get_project(
+        self, project_name: str, include_archived: bool = False
+    ) -> ProjectPayload:
         """Return all sessions for a specific project."""
-        all_sessions = self.get_all_sessions()
+        all_sessions = self.get_all_sessions(include_archived=include_archived)
         sessions = [s for s in all_sessions if s["project"] == project_name]
 
         return ProjectPayload(
@@ -442,7 +500,7 @@ class FennScanner:
                 and parsed["project"] == project_name
                 and parsed["session_id"] == session_id
             ):
-                parsed = self._with_display_name(parsed)
+                parsed = self._with_overrides(parsed)
                 overview = self.get_overview()
                 return cast(
                     SessionPagePayload,
@@ -463,6 +521,7 @@ class FennScanner:
         self,
         project: str | None = None,
         status: str | None = None,
+        include_archived: bool = False,
         started_after: datetime | None = None,
         started_before: datetime | None = None,
         limit: int = 20,
@@ -491,7 +550,7 @@ class FennScanner:
         if field not in _VALID_SORT_FIELDS:
             raise ValueError(f"sort field must be one of {list(_VALID_SORT_FIELDS)}")
 
-        sessions = self.get_all_sessions()
+        sessions = self.get_all_sessions(include_archived=include_archived)
         if project:
             sessions = [s for s in sessions if s["project"] == project]
         if status:

--- a/fenn/dashboard/static/app.js
+++ b/fenn/dashboard/static/app.js
@@ -20,6 +20,12 @@
     });
   }
 
+  const includeArchivedVisible = (() => {
+    const value = new URLSearchParams(window.location.search).get("include_archived");
+    if (!value) return false;
+    return value.toLowerCase() === "true";
+  })();
+
   function updateSearchableRow(row) {
     if (!row) return;
     const parts = [];
@@ -63,6 +69,75 @@
     const subtitle = document.getElementById("session-display-name-subtitle");
     if (subtitle && subtitle.querySelector(".session-display-name")) {
       subtitle.querySelector(".session-display-name").textContent = shown;
+    }
+  }
+
+  function applyArchivedState(project, sessionId, archived) {
+    const nodes = document.querySelectorAll(
+      `[data-project='${CSS.escape(project)}'][data-session='${CSS.escape(sessionId)}']`
+    );
+    nodes.forEach((node) => {
+      if (node.matches("tr")) {
+        if (archived && !includeArchivedVisible) {
+          node.remove();
+          return;
+        }
+
+        node.dataset.archived = archived ? "true" : "false";
+        const searchable = node.getAttribute("data-searchable") || "";
+        if (archived && !searchable.includes("archived")) {
+          node.setAttribute("data-searchable", `${searchable} archived`.trim());
+        }
+        if (!archived && searchable.includes("archived")) {
+          node.setAttribute(
+            "data-searchable",
+            searchable.replace(/\barchived\b/g, "").replace(/\s+/g, " ").trim()
+          );
+        }
+
+        const statusCell = node.querySelector(".session-status-cell");
+        if (statusCell) {
+          const existing = statusCell.querySelector(".badge-archived");
+          if (archived && !existing) {
+            const badge = document.createElement("span");
+            badge.className = "badge badge-archived";
+            badge.textContent = "archived";
+            statusCell.insertBefore(badge, statusCell.firstChild);
+          }
+          if (!archived && existing) {
+            existing.remove();
+          }
+        }
+
+        const actionsCell = node.querySelector(".session-actions-cell");
+        const toggleBtn = actionsCell?.querySelector(
+          ".archive-session-btn, .restore-session-btn"
+        );
+        if (toggleBtn) {
+          toggleBtn.classList.toggle("archive-session-btn", !archived);
+          toggleBtn.classList.toggle("restore-session-btn", archived);
+          toggleBtn.textContent = archived ? "Restore" : "Archive";
+        }
+      }
+    });
+
+    const sessionStatusEl = document.getElementById("session-status");
+    if (
+      sessionStatusEl &&
+      sessionStatusEl.dataset.project === project &&
+      sessionStatusEl.dataset.session === sessionId
+    ) {
+      sessionStatusEl.dataset.archived = archived ? "true" : "false";
+      const badge = document.getElementById("session-archived-badge");
+      if (badge) {
+        badge.style.display = archived ? "inline-flex" : "none";
+      }
+      const toggleBtn = document.getElementById("session-archive-toggle");
+      if (toggleBtn) {
+        toggleBtn.textContent = archived ? "Restore" : "Archive";
+        toggleBtn.classList.toggle("archive-session-btn", !archived);
+        toggleBtn.classList.toggle("restore-session-btn", archived);
+      }
     }
   }
 
@@ -318,6 +393,32 @@
       return;
     } finally {
       deleteDialog?.close();
+    }
+  });
+
+  document.addEventListener("click", async (e) => {
+    const btn = e.target.closest(".archive-session-btn, .restore-session-btn");
+    if (!btn) return;
+
+    const project = btn.dataset.project;
+    const sessionId = btn.dataset.session;
+    if (!project || !sessionId) return;
+
+    const archived = btn.classList.contains("archive-session-btn");
+    const endpoint = archived ? "archive" : "restore";
+    try {
+      const resp = await postJson(
+        `/api/session/${encodeURIComponent(project)}/${encodeURIComponent(sessionId)}/${endpoint}`,
+        {}
+      );
+      const body = await resp.json().catch(() => ({}));
+      if (!resp.ok) {
+        window.alert(body?.error?.message || `${endpoint} failed`);
+        return;
+      }
+      applyArchivedState(project, sessionId, Boolean(body.archived));
+    } catch (_err) {
+      window.alert(`${endpoint} failed`);
     }
   });
 

--- a/fenn/dashboard/static/style.css
+++ b/fenn/dashboard/static/style.css
@@ -411,6 +411,7 @@ tbody tr:hover { background: var(--bg-elevated); }
 .badge-running   { color: var(--accent);  border-color: var(--border-glow); }
 .badge-crashed   { color: var(--warning); border-color: rgba(234,179,8,.35); }
 .badge-failed    { color: var(--error);   border-color: rgba(248,81,73,.35); }
+.badge-archived  { color: var(--text-mute); border-color: var(--border); }
 .badge-info      { color: #79c0ff;        border-color: rgba(121,192,255,.35); }
 .badge-warning   { color: var(--warning); border-color: rgba(234,179,8,.35); }
 .badge-exception { color: var(--error);   border-color: rgba(248,81,73,.35); }

--- a/fenn/dashboard/templates/index.html
+++ b/fenn/dashboard/templates/index.html
@@ -81,6 +81,11 @@
 {% if recent_sessions %}
 <div class="section-header">
   <span class="section-title">Recent Sessions</span>
+  {% if include_archived %}
+  <a class="btn btn-sm" href="/">Hide archived</a>
+  {% else %}
+  <a class="btn btn-sm" href="/?include_archived=true">Show archived</a>
+  {% endif %}
 </div>
 <div class="search-bar">
   <input class="search-input form-control" type="text" placeholder="Search sessions..." id="session-search" />    
@@ -105,7 +110,7 @@
       </thead>
       <tbody>
         {% for s in recent_sessions %}
-        <tr data-searchable="{{ s.project }} {{ s.session_id }} {{ s.display_name or '' }}" data-project="{{ s.project }}" data-session="{{ s.session_id }}">
+        <tr data-searchable="{{ s.project }} {{ s.session_id }} {{ s.display_name or '' }} {{ 'archived' if s.archived else '' }}" data-project="{{ s.project }}" data-session="{{ s.session_id }}" data-archived="{{ 'true' if s.archived else 'false' }}">
           <td data-searchable="{{ s.project }}">
             <a href="/project/{{ s.project | urlencode }}">{{ s.project }}</a>
           </td>
@@ -123,7 +128,10 @@
           </td>
           <td class="td-mono" data-searchable="{{ s.started }}">{{ s.started }}</td>
           <td class="td-mono" data-searchable="{{ s.duration_s | duration }} ">{{ s.duration_s | duration }}</td>
-          <td data-searchable="{{ s.status }}">
+          <td class="session-status-cell" data-searchable="{{ s.status }}">
+            {% if s.archived %}
+            <span class="badge badge-archived">archived</span>
+            {% endif %}
             {% if s.status == 'crashed' %}
             <span class="badge badge-crashed">crashed</span>
             {% elif s.status == 'failed' %}
@@ -143,7 +151,18 @@
               style="{% if s.exception_count > 0 %}color:var(--error){% endif %}">
             {{ s.exception_count if s.exception_count else '—' }}
           </td>
-          <td>
+          <td class="session-actions-cell">
+              {% if s.archived %}
+              <button type="button"
+                class="btn btn-sm restore-session-btn"
+                data-project="{{ s.project }}"
+                data-session="{{ s.session_id }}">Restore</button>
+              {% else %}
+              <button type="button"
+                class="btn btn-sm archive-session-btn"
+                data-project="{{ s.project }}"
+                data-session="{{ s.session_id }}">Archive</button>
+              {% endif %}
             <button type="button"
                     class="btn btn-sm delete-session-btn"
                     data-project="{{ s.project }}"

--- a/fenn/dashboard/templates/project.html
+++ b/fenn/dashboard/templates/project.html
@@ -43,6 +43,11 @@
 {% if sessions %}
 <div class="section-header">
   <span class="section-title">Sessions</span>
+  {% if include_archived %}
+  <a class="btn btn-sm" href="/project/{{ project_name | urlencode }}">Hide archived</a>
+  {% else %}
+  <a class="btn btn-sm" href="/project/{{ project_name | urlencode }}?include_archived=true">Show archived</a>
+  {% endif %}
 </div>
 
 <div class="card">
@@ -64,8 +69,8 @@
       </thead>
       <tbody>
         {% for s in sessions %}
-        <tr data-searchable="{{ s.session_id }} {{ s.display_name or '' }} {{ s.started }}" data-project="{{ s.project }}" data-session="{{ s.session_id }}">
-          <td>
+        <tr data-searchable="{{ s.session_id }} {{ s.display_name or '' }} {{ s.started }} {{ 'archived' if s.archived else '' }}" data-project="{{ s.project }}" data-session="{{ s.session_id }}" data-archived="{{ 'true' if s.archived else 'false' }}">
+          <td class="session-status-cell">
             <a href="/session/{{ s.project | urlencode }}/{{ s.session_id | urlencode }}"
                class="td-mono"
                title="{{ s.session_id }}">{{ s.session_id }}</a>
@@ -80,7 +85,10 @@
           </td>
           <td class="td-mono">{{ s.started }}</td>
           <td class="td-mono">{{ s.duration_s | duration }}</td>
-          <td>
+          <td class="session-actions-cell">
+            {% if s.archived %}
+            <span class="badge badge-archived">archived</span>
+            {% endif %}
             {% if s.status == 'running' %}
             <span class="badge badge-running">
               <span class="pulse-dot"></span>running
@@ -102,6 +110,17 @@
           </td>
           <td class="td-mono">{{ s.file_size | filesize }}</td>
           <td>
+              {% if s.archived %}
+              <button type="button"
+                class="btn btn-sm restore-session-btn"
+                data-project="{{ s.project }}"
+                data-session="{{ s.session_id }}">Restore</button>
+              {% else %}
+              <button type="button"
+                class="btn btn-sm archive-session-btn"
+                data-project="{{ s.project }}"
+                data-session="{{ s.session_id }}">Archive</button>
+              {% endif %}
             <button type="button"
                     class="btn btn-sm delete-session-btn"
                     data-project="{{ s.project }}"

--- a/fenn/dashboard/templates/session.html
+++ b/fenn/dashboard/templates/session.html
@@ -17,6 +17,7 @@
       data-status="{{ status }}"
       data-project="{{ project }}"
       data-session="{{ session_id }}"
+  data-archived="{{ 'true' if archived else 'false' }}"
       style="display:none;"></span>
 
 <!-- Header -->
@@ -35,6 +36,11 @@
     {% else %}
     <span class="badge badge-completed" style="font-size:12px; margin-left:8px; vertical-align:middle;">completed</span>
     {% endif %}
+    {% if archived %}
+    <span class="badge badge-archived" id="session-archived-badge" style="font-size:12px; margin-left:8px; vertical-align:middle;">archived</span>
+    {% else %}
+    <span class="badge badge-archived" id="session-archived-badge" style="font-size:12px; margin-left:8px; vertical-align:middle; display:none;">archived</span>
+    {% endif %}
   </h1>
   <p class="page-subtitle" id="session-display-name-subtitle">
     Display name: <span class="session-display-name">{{ display_name or '—' }}</span>
@@ -44,6 +50,11 @@
             data-session="{{ session_id }}"
             data-current-name="{{ display_name or '' }}">Rename</button>
     <button type="button"
+          class="btn btn-sm {% if archived %}restore-session-btn{% else %}archive-session-btn{% endif %}"
+          id="session-archive-toggle"
+          data-project="{{ project }}"
+          data-session="{{ session_id }}">{% if archived %}Restore{% else %}Archive{% endif %}</button>
+        <button type="button"
             class="btn btn-sm delete-session-btn"
             data-project="{{ project }}"
             data-session="{{ session_id }}">Delete</button>

--- a/fenn/dashboard/types.py
+++ b/fenn/dashboard/types.py
@@ -31,6 +31,7 @@ class SessionData(TypedDict):
 
     session_id: str
     display_name: str | None
+    archived: bool
     project: str
     started: str
     ended: str | None
@@ -54,6 +55,7 @@ class SessionListItem(TypedDict):
 
     session_id: str
     display_name: str | None
+    archived: bool
     project: str
     started: str
     ended: str | None
@@ -110,6 +112,7 @@ class SessionPagePayload(TypedDict):
 
     session_id: str
     display_name: str | None
+    archived: bool
     project: str
     started: str
     ended: str | None

--- a/tests/unit/dashboard/test_api.py
+++ b/tests/unit/dashboard/test_api.py
@@ -95,10 +95,11 @@ def client(scanner_with_sessions):
 
 
 @pytest.fixture()
-def client_no_auth(scanner_with_sessions):
+def client_no_auth(scanner_with_sessions, monkeypatch):
     """Flask test client using scanner fixture, but without logged-in user."""
     import fenn.dashboard.app as app_module
 
+    monkeypatch.setattr(app_module.token_store, "load", lambda: None)
     original = app_module.scanner
     app_module.scanner = scanner_with_sessions
     app.config["TESTING"] = True
@@ -364,6 +365,45 @@ class TestSessionMutationRoutes:
         )
         assert resp.status_code == 404
 
+    def test_archive_and_restore_session_success(self, client):
+        token = _extract_csrf_token(client.get("/").get_data(as_text=True))
+        assert token
+
+        archive_resp = client.post(
+            "/api/session/alpha/a1/archive",
+            json={},
+            headers={"X-CSRFToken": token},
+        )
+        assert archive_resp.status_code == 200
+        assert archive_resp.get_json()["archived"] is True
+
+        detail = client.get("/api/session/alpha/a1")
+        assert detail.status_code == 200
+        assert detail.get_json()["archived"] is True
+
+        restore_resp = client.post(
+            "/api/session/alpha/a1/restore",
+            json={},
+            headers={"X-CSRFToken": token},
+        )
+        assert restore_resp.status_code == 200
+        assert restore_resp.get_json()["archived"] is False
+
+        detail_after = client.get("/api/session/alpha/a1")
+        assert detail_after.status_code == 200
+        assert detail_after.get_json()["archived"] is False
+
+    def test_archive_unknown_session_returns_404(self, client):
+        token = _extract_csrf_token(client.get("/").get_data(as_text=True))
+        assert token
+
+        resp = client.post(
+            "/api/session/alpha/nope/archive",
+            json={},
+            headers={"X-CSRFToken": token},
+        )
+        assert resp.status_code == 404
+
     def test_mutation_routes_without_auth_redirect_to_connect(self, client_no_auth):
         token = _extract_csrf_token(
             client_no_auth.get("/connect").get_data(as_text=True)
@@ -392,9 +432,31 @@ class TestSessionMutationRoutes:
             json={"display_name": "x"},
         )
         delete_resp = client.post("/api/session/alpha/a1/delete", json={})
+        archive_resp = client.post("/api/session/alpha/a1/archive", json={})
+        restore_resp = client.post("/api/session/alpha/a1/restore", json={})
 
         assert rename_resp.status_code == 400
         assert delete_resp.status_code == 400
+        assert archive_resp.status_code == 400
+        assert restore_resp.status_code == 400
+
+    def test_api_sessions_include_archived_query_param(self, client):
+        token = _extract_csrf_token(client.get("/").get_data(as_text=True))
+        assert token
+        archive_resp = client.post(
+            "/api/session/alpha/a1/archive",
+            json={},
+            headers={"X-CSRFToken": token},
+        )
+        assert archive_resp.status_code == 200
+
+        default_resp = client.get("/api/sessions")
+        default_ids = {item["session_id"] for item in default_resp.get_json()["items"]}
+        assert "a1" not in default_ids
+
+        include_resp = client.get("/api/sessions?include_archived=true")
+        include_ids = {item["session_id"] for item in include_resp.get_json()["items"]}
+        assert "a1" in include_ids
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/dashboard/test_scanner.py
+++ b/tests/unit/dashboard/test_scanner.py
@@ -178,3 +178,108 @@ class TestSessionMutations:
         scanner = FennScanner(extra_dirs=[str(tmp_path)])
 
         assert scanner.delete_session("proj", "missing") is False
+
+    def test_archive_session_sets_flag_and_persists(self, tmp_path, monkeypatch):
+        overrides_path = tmp_path / "dashboard_overrides.json"
+        monkeypatch.setenv("FENN_DASHBOARD_OVERRIDES_PATH", str(overrides_path))
+        _write(tmp_path / "s1.fn", _SAMPLE_FN.format(project="proj", sid="s1"))
+
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+        assert scanner.archive_session("proj", "s1") is True
+
+        s1 = scanner.get_session("proj", "s1")
+        assert s1 is not None
+        assert s1["archived"] is True
+
+        scanner_reloaded = FennScanner(extra_dirs=[str(tmp_path)])
+        s1_reloaded = scanner_reloaded.get_session("proj", "s1")
+        assert s1_reloaded is not None
+        assert s1_reloaded["archived"] is True
+
+    def test_restore_session_clears_archived_flag(self, tmp_path, monkeypatch):
+        overrides_path = tmp_path / "dashboard_overrides.json"
+        monkeypatch.setenv("FENN_DASHBOARD_OVERRIDES_PATH", str(overrides_path))
+        _write(tmp_path / "s1.fn", _SAMPLE_FN.format(project="proj", sid="s1"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        assert scanner.archive_session("proj", "s1") is True
+        assert scanner.restore_session("proj", "s1") is True
+
+        s1 = scanner.get_session("proj", "s1")
+        assert s1 is not None
+        assert s1["archived"] is False
+
+    def test_archive_restore_unknown_session_returns_false(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "FENN_DASHBOARD_OVERRIDES_PATH", str(tmp_path / "dashboard_overrides.json")
+        )
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        assert scanner.archive_session("proj", "missing") is False
+        assert scanner.restore_session("proj", "missing") is False
+
+    def test_archived_session_filtered_from_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "FENN_DASHBOARD_OVERRIDES_PATH", str(tmp_path / "dashboard_overrides.json")
+        )
+        _write(tmp_path / "s1.fn", _SAMPLE_FN.format(project="proj", sid="s1"))
+        _write(tmp_path / "s2.fn", _SAMPLE_FN.format(project="proj", sid="s2"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        assert scanner.archive_session("proj", "s1") is True
+
+        default_ids = {s["session_id"] for s in scanner.get_all_sessions()}
+        all_ids = {
+            s["session_id"] for s in scanner.get_all_sessions(include_archived=True)
+        }
+        assert default_ids == {"s2"}
+        assert all_ids == {"s1", "s2"}
+
+    def test_list_sessions_include_archived_flag(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "FENN_DASHBOARD_OVERRIDES_PATH", str(tmp_path / "dashboard_overrides.json")
+        )
+        _write(tmp_path / "s1.fn", _SAMPLE_FN.format(project="proj", sid="s1"))
+        _write(tmp_path / "s2.fn", _SAMPLE_FN.format(project="proj", sid="s2"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+        assert scanner.archive_session("proj", "s1") is True
+
+        default_list = scanner.list_sessions()
+        full_list = scanner.list_sessions(include_archived=True)
+
+        assert {s["session_id"] for s in default_list["items"]} == {"s2"}
+        assert {s["session_id"] for s in full_list["items"]} == {"s1", "s2"}
+
+    def test_archiving_preserves_display_name(self, tmp_path, monkeypatch):
+        overrides_path = tmp_path / "dashboard_overrides.json"
+        monkeypatch.setenv("FENN_DASHBOARD_OVERRIDES_PATH", str(overrides_path))
+        _write(tmp_path / "s1.fn", _SAMPLE_FN.format(project="proj", sid="s1"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+
+        assert scanner.rename_session("proj", "s1", "Friendly") is True
+        assert scanner.archive_session("proj", "s1") is True
+
+        payload = json.loads(overrides_path.read_text(encoding="utf-8"))
+        assert payload["s1"]["display_name"] == "Friendly"
+        assert payload["s1"]["archived"] is True
+
+    def test_overview_project_counts_exclude_archived_by_default(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv(
+            "FENN_DASHBOARD_OVERRIDES_PATH", str(tmp_path / "dashboard_overrides.json")
+        )
+        _write(tmp_path / "s1.fn", _SAMPLE_FN.format(project="proj", sid="s1"))
+        _write(tmp_path / "s2.fn", _SAMPLE_FN.format(project="proj", sid="s2"))
+        scanner = FennScanner(extra_dirs=[str(tmp_path)])
+        assert scanner.archive_session("proj", "s1") is True
+
+        overview_default = scanner.get_overview()
+        overview_all = scanner.get_overview(include_archived=True)
+        project_default = scanner.get_project("proj")
+        project_all = scanner.get_project("proj", include_archived=True)
+
+        assert overview_default["total_sessions"] == 1
+        assert overview_all["total_sessions"] == 2
+        assert project_default["total_sessions"] == 1
+        assert project_all["total_sessions"] == 2


### PR DESCRIPTION
Fixes: #254

## Changes
* Added non-destructive soft delete support for dashboard sessions by introducing an `archived` flag in the session override metadata store.
* Implemented scanner-level archive lifecycle operations:
  * `archive_session()` to mark sessions as archived (without deleting `.fn` files)
  * `restore_session()` to unarchive sessions
  * archived-session filtering in listings, with opt-in inclusion support
* Added new authenticated, CSRF-protected API endpoints:
  * `POST /api/session/<project>/<session>/archive`
  * `POST /api/session/<project>/<session>/restore`
* Added archived-session query support (`include_archived`) for dashboard/API listing flows.
* Updated dashboard UI to:
  * Show Archive/Restore actions alongside existing rename/delete controls
  * Hide archived sessions by default and allow explicit archived visibility mode
  * Keep existing rename/delete interactions working with the new archive state
* Added tests for soft delete behavior, including scanner and API coverage.

## Notes
* Soft delete is metadata-only: archiving does **not** modify or remove underlying `.fn` experiment log files.
* Archived state is persisted in the dashboard override store and can be toggled via restore at any time.
* Existing hard delete remains available for permanent removal when explicitly requested.
* Archived filtering now defaults to hidden unless `include_archived=true` is provided.