### PR TITLE
fix: [#257] Resolve `profile execute` to cwd instead of package install dir 

### DIFF
--- a/fenn/cli/profile.py
+++ b/fenn/cli/profile.py
@@ -14,8 +14,6 @@ from pathlib import Path
 
 from fenn.logging import logger, original_print
 
-ROOT = Path(__file__).resolve().parents[1]
-
 
 def execute(args: argparse.Namespace) -> None:
     """Run the fenn template under cProfile and write profiling output.
@@ -25,14 +23,14 @@ def execute(args: argparse.Namespace) -> None:
             - template: name of the template folder to profile
             - limit: number of lines to include in the report
     """
-    template = ROOT / args.template
+    template = (Path.cwd() / args.template).resolve()
     entrypoint = template / "main.py"
 
-    if not entrypoint.is_file() or template.parent != ROOT:
+    if not entrypoint.is_file():
         logger.error(f"Unknown template: {args.template}")
         sys.exit(1)
 
-    output_dir = ROOT / "profiling_results" / args.template
+    output_dir = (Path.cwd() / "profiling_results" / args.template).resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
     profile_path = output_dir / "cprofile.prof"

--- a/tests/unit/cli/test_profile_command.py
+++ b/tests/unit/cli/test_profile_command.py
@@ -3,6 +3,8 @@
 import logging
 from unittest.mock import Mock
 
+import pytest
+
 from fenn.cli import build_parser, profile
 
 
@@ -22,27 +24,28 @@ def test_profile_parser_accepts_limit() -> None:
     assert args.limit == 10
 
 
+@pytest.mark.parametrize("template_name", ["default", "nested/default"])
 def test_profile_execute_generates_profile_and_report(
-    tmp_path, monkeypatch, caplog
+    tmp_path, monkeypatch, caplog, template_name
 ) -> None:
     """Execute profile and verify output files are created and reported."""
-    monkeypatch.setattr(profile, "ROOT", tmp_path)
+    monkeypatch.chdir(tmp_path)
 
-    template_dir = tmp_path / "default"
-    template_dir.mkdir()
+    template_dir = tmp_path / template_name
+    template_dir.mkdir(parents=True)
     (template_dir / "main.py").write_text(
         "print('hello')\n",
         encoding="utf-8",
     )
 
     args = Mock()
-    args.template = "default"
+    args.template = template_name
     args.limit = 5
 
     caplog.set_level(logging.INFO)
     profile.execute(args)
 
-    output_dir = tmp_path / "profiling_results" / "default"
+    output_dir = tmp_path / "profiling_results" / template_name
     profile_file = output_dir / "cprofile.prof"
     report_file = output_dir / "cprofile.txt"
 
@@ -54,3 +57,19 @@ def test_profile_execute_generates_profile_and_report(
     assert "Report:" in log_output
     assert str(profile_file) in log_output
     assert str(report_file) in log_output
+
+
+def test_profile_execute_raises_exit_code(tmp_path, monkeypatch):
+    """Verify system exit is raised when profile execute is called on
+    template dir missing main.py."""
+    monkeypatch.chdir(tmp_path)
+    template_dir = tmp_path / "missing_main"
+    template_dir.mkdir()
+
+    args = Mock()
+    args.template = "missing_main"
+
+    with pytest.raises(SystemExit) as exc_info:
+        profile.execute(args)
+
+    assert exc_info.value.code == 1


### PR DESCRIPTION
## Description

Fixes #257. 
- Resolves the template path used by `profile.execute()` against cwd instead of `Path(__file__).resolve().parents[1]` (the package install dir), so it can locate templates pulled via `fenn pull`.
- Removes the `template.parent != ROOT` guard to allow profiling of templates nested within cwd.
- Updates `test_profile_execute_generates_profile_and_report` to parametrize over flat and nested templates; retains original coverage for the non-nested case.
- Adds a regression test verifying `profile.execute()` raises `SystemExit(1)` for a template dir missing `main.py`.

## Verification 
- Ran the entire test suite: all passing.
- Pre-commit checks: all passing.
