### PR TITLE
feat(dashboard)[#265]: add local template registry for dashboard template discovery

### DIFF
--- a/fenn/cli/pull.py
+++ b/fenn/cli/pull.py
@@ -4,11 +4,13 @@ import subprocess
 import sys
 import tempfile
 import zipfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
 from colorama import Fore, Style
 
+from fenn.dashboard.templates_registry import TemplateEntry, TemplatesRegistry
 from fenn.exceptions import NetworkError, TemplateError, TemplateNotFoundError
 from fenn.logging import logger
 
@@ -229,7 +231,31 @@ def pull_template(
         )
 
     _download_template(template_name, target_dir, force)
+    _register_pulled_template(template_name, target_dir)
     return target_dir
+
+
+def _register_pulled_template(template_name: str, target_dir: Path) -> None:
+    """Record a successful pull in the local templates registry.
+
+    Args:
+        template_name: Name of the template that was pulled.
+        target_dir: Directory where the template was extracted.
+    """
+    try:
+        TemplatesRegistry().add_or_update(
+            TemplateEntry(
+                name=target_dir.name,
+                path=str(target_dir),
+                source_template=template_name,
+                pulled_at=datetime.now(timezone.utc).isoformat(),
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            f"{Fore.YELLOW}Pulled template but failed to update the local "
+            f"templates registry: {exc}{Style.RESET_ALL}"
+        )
 
 
 def _download_template(template_name: str, target_dir: Path, force: bool) -> None:

--- a/fenn/dashboard/templates_registry.py
+++ b/fenn/dashboard/templates_registry.py
@@ -1,0 +1,143 @@
+"""Local registry of templates downloaded via `fenn pull`."""
+
+import json
+import os
+from pathlib import Path
+
+from fenn.dashboard.types import TemplateEntry
+
+_DEFAULT_REGISTRY_PATH = "~/.fenn/templates_registry.json"
+
+
+def _default_registry_path() -> Path:
+    """Resolve the registry path, honoring FENN_TEMPLATES_REGISTRY_PATH.
+
+    Returns:
+        The path to the local templates registry file.
+    """
+    return Path(
+        os.environ.get("FENN_TEMPLATES_REGISTRY_PATH", _DEFAULT_REGISTRY_PATH)
+    ).expanduser()
+
+
+class TemplatesRegistry:
+    """Reads and writes the local template registry."""
+
+    def __init__(self, registry_path: Path | None = None) -> None:
+        self._path = registry_path or _default_registry_path()
+
+    # ------------------------------------------------------------------
+    # Internal load/save helpers
+    # ------------------------------------------------------------------
+
+    def _load_raw(self) -> dict[str, TemplateEntry]:
+        """Load and validate the registry file, tolerating missing/corrupt data.
+
+        Returns:
+            The raw registry entries as a dictionary keyed by template path.
+        """
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+        except OSError:
+            return {}
+
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+
+        if not isinstance(payload, dict):
+            return {}
+
+        cleaned: dict[str, TemplateEntry] = {}
+        for key, entry in payload.items():
+            if not isinstance(key, str) or not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            path = entry.get("path")
+            source_template = entry.get("source_template")
+            pulled_at = entry.get("pulled_at")
+            if not all(
+                isinstance(v, str) and v
+                for v in (name, path, source_template, pulled_at)
+            ):
+                continue
+            cleaned[key] = TemplateEntry(
+                name=name,
+                path=path,
+                source_template=source_template,
+                pulled_at=pulled_at,
+            )
+        return cleaned
+
+    def _save_raw(self, entries: dict[str, TemplateEntry]) -> None:
+        """Persist the registry atomically.
+
+        Args:
+            entries: The registry entries to save.
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp_path.write_text(
+            json.dumps(entries, ensure_ascii=True, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        os.replace(tmp_path, self._path)
+
+    @staticmethod
+    def _prune_missing(
+        entries: dict[str, TemplateEntry],
+    ) -> tuple[dict[str, TemplateEntry], bool]:
+        """Drop entries whose directory no longer exists on disk.
+
+        Args:
+            entries: The registry entries to prune.
+
+        Returns:
+            A tuple containing the pruned entries and a boolean indicating if any entries were removed.
+        """
+        pruned: dict[str, TemplateEntry] = {}
+        changed = False
+        for key, entry in entries.items():
+            if Path(entry["path"]).exists():
+                pruned[key] = entry
+            else:
+                changed = True
+        return pruned, changed
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def list_templates(self) -> list[TemplateEntry]:
+        """Return all registered templates, most recently pulled first.
+
+        Returns:
+            A list of all registered templates, most recently pulled first.
+        """
+        entries = self._load_raw()
+        pruned, changed = self._prune_missing(entries)
+        if changed:
+            try:
+                self._save_raw(pruned)
+            except OSError:
+                pass
+        return sorted(pruned.values(), key=lambda e: e["pulled_at"], reverse=True)
+
+    def add_or_update(self, entry: TemplateEntry) -> None:
+        """Add or update a registry entry, keyed by its resolved absolute path.
+
+        Args:
+            entry: The template entry to add or update.
+        """
+        entries = self._load_raw()
+        entries, _ = self._prune_missing(entries)
+
+        resolved_path = str(Path(entry["path"]).resolve())
+        entries[resolved_path] = TemplateEntry(
+            name=entry["name"],
+            path=resolved_path,
+            source_template=entry["source_template"],
+            pulled_at=entry["pulled_at"],
+        )
+        self._save_raw(entries)

--- a/fenn/dashboard/types.py
+++ b/fenn/dashboard/types.py
@@ -142,3 +142,12 @@ class SessionListResponse(TypedDict):
     total: int
     limit: int
     offset: int
+
+
+class TemplateEntry(TypedDict):
+    """A single registered template."""
+
+    name: str
+    path: str
+    source_template: str
+    pulled_at: str

--- a/tests/unit/dashboard/test_templates_registry.py
+++ b/tests/unit/dashboard/test_templates_registry.py
@@ -1,0 +1,264 @@
+"""Unit tests for fenn.dashboard.templates_registry."""
+
+import json
+
+import pytest
+
+from fenn.dashboard.templates_registry import TemplateEntry, TemplatesRegistry
+
+
+def _entry(
+    name: str,
+    path,
+    source_template: str = "base",
+    pulled_at: str = "2026-07-21T10:00:00+00:00",
+) -> TemplateEntry:
+    return TemplateEntry(
+        name=name,
+        path=str(path),
+        source_template=source_template,
+        pulled_at=pulled_at,
+    )
+
+
+@pytest.fixture
+def registry_path(tmp_path):
+    return tmp_path / ".fenn" / "templates_registry.json"
+
+
+@pytest.fixture
+def registry(registry_path):
+    return TemplatesRegistry(registry_path=registry_path)
+
+
+class TestCreation:
+    def test_list_templates_on_missing_file_returns_empty(self, registry):
+        assert registry.list_templates() == []
+
+    def test_add_or_update_creates_registry_file(
+        self, tmp_path, registry, registry_path
+    ):
+        template_dir = tmp_path / "my_template"
+        template_dir.mkdir()
+
+        assert not registry_path.exists()
+        registry.add_or_update(_entry("my_template", template_dir))
+
+        assert registry_path.exists()
+
+    def test_add_or_update_persists_all_fields(self, tmp_path, registry, registry_path):
+        template_dir = tmp_path / "my_template"
+        template_dir.mkdir()
+
+        registry.add_or_update(
+            _entry(
+                "my_template",
+                template_dir,
+                source_template="vision",
+                pulled_at="2026-07-21T12:34:56+00:00",
+            )
+        )
+
+        [entry] = registry.list_templates()
+        assert entry["name"] == "my_template"
+        assert entry["path"] == str(template_dir.resolve())
+        assert entry["source_template"] == "vision"
+        assert entry["pulled_at"] == "2026-07-21T12:34:56+00:00"
+
+    def test_add_or_update_keys_entries_by_resolved_path(
+        self, tmp_path, registry, registry_path
+    ):
+        template_dir = tmp_path / "my_template"
+        template_dir.mkdir()
+
+        registry.add_or_update(_entry("my_template", template_dir))
+
+        raw = json.loads(registry_path.read_text())
+        assert list(raw.keys()) == [str(template_dir.resolve())]
+
+    def test_registry_file_is_valid_json_on_disk(
+        self, tmp_path, registry, registry_path
+    ):
+        template_dir = tmp_path / "my_template"
+        template_dir.mkdir()
+        registry.add_or_update(_entry("my_template", template_dir))
+
+        # Should not raise.
+        json.loads(registry_path.read_text())
+
+    def test_corrupt_registry_file_is_tolerated(self, registry_path, registry):
+        registry_path.parent.mkdir(parents=True, exist_ok=True)
+        registry_path.write_text("not valid json{{{")
+
+        assert registry.list_templates() == []
+
+    def test_non_dict_json_payload_is_tolerated(self, registry_path, registry):
+        registry_path.parent.mkdir(parents=True, exist_ok=True)
+        registry_path.write_text(json.dumps(["not", "a", "dict"]))
+
+        assert registry.list_templates() == []
+
+    def test_entries_missing_required_fields_are_dropped(self, registry_path, registry):
+        registry_path.parent.mkdir(parents=True, exist_ok=True)
+        registry_path.write_text(
+            json.dumps({"/some/path": {"name": "incomplete"}})  # missing fields
+        )
+
+        assert registry.list_templates() == []
+
+
+class TestUpdates:
+    def test_add_or_update_twice_with_same_path_does_not_duplicate(
+        self, tmp_path, registry
+    ):
+        template_dir = tmp_path / "my_template"
+        template_dir.mkdir()
+
+        registry.add_or_update(
+            _entry("my_template", template_dir, pulled_at="2026-07-20T00:00:00+00:00")
+        )
+        registry.add_or_update(
+            _entry("my_template", template_dir, pulled_at="2026-07-21T00:00:00+00:00")
+        )
+
+        entries = registry.list_templates()
+        assert len(entries) == 1
+
+    def test_add_or_update_overwrites_fields_on_re_pull(self, tmp_path, registry):
+        template_dir = tmp_path / "my_template"
+        template_dir.mkdir()
+
+        registry.add_or_update(
+            _entry(
+                "my_template",
+                template_dir,
+                source_template="base",
+                pulled_at="2026-07-20T00:00:00+00:00",
+            )
+        )
+        registry.add_or_update(
+            _entry(
+                "my_template",
+                template_dir,
+                source_template="base",
+                pulled_at="2026-07-21T00:00:00+00:00",
+            )
+        )
+
+        [entry] = registry.list_templates()
+        assert entry["pulled_at"] == "2026-07-21T00:00:00+00:00"
+
+    def test_multiple_distinct_templates_are_all_kept(self, tmp_path, registry):
+        dir_a = tmp_path / "template_a"
+        dir_b = tmp_path / "template_b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        registry.add_or_update(
+            _entry("template_a", dir_a, pulled_at="2026-07-20T00:00:00+00:00")
+        )
+        registry.add_or_update(
+            _entry("template_b", dir_b, pulled_at="2026-07-21T00:00:00+00:00")
+        )
+
+        entries = registry.list_templates()
+        assert {e["name"] for e in entries} == {"template_a", "template_b"}
+
+    def test_list_templates_sorted_newest_pulled_first(self, tmp_path, registry):
+        dir_a = tmp_path / "template_a"
+        dir_b = tmp_path / "template_b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        registry.add_or_update(
+            _entry("template_a", dir_a, pulled_at="2026-07-20T00:00:00+00:00")
+        )
+        registry.add_or_update(
+            _entry("template_b", dir_b, pulled_at="2026-07-21T00:00:00+00:00")
+        )
+
+        entries = registry.list_templates()
+        assert [e["name"] for e in entries] == ["template_b", "template_a"]
+
+
+class TestPruning:
+    def test_deleted_template_directory_is_removed_from_list(self, tmp_path, registry):
+        template_dir = tmp_path / "my_template"
+        template_dir.mkdir()
+        registry.add_or_update(_entry("my_template", template_dir))
+
+        assert len(registry.list_templates()) == 1
+
+        import shutil
+
+        shutil.rmtree(template_dir)
+
+        assert registry.list_templates() == []
+
+    def test_pruned_entry_is_persisted_to_disk(self, tmp_path, registry, registry_path):
+        template_dir = tmp_path / "my_template"
+        template_dir.mkdir()
+        registry.add_or_update(_entry("my_template", template_dir))
+
+        import shutil
+
+        shutil.rmtree(template_dir)
+        registry.list_templates()  # triggers prune + save
+
+        raw = json.loads(registry_path.read_text())
+        assert raw == {}
+
+    def test_pruning_only_removes_missing_entries_not_valid_ones(
+        self, tmp_path, registry
+    ):
+        dir_a = tmp_path / "template_a"
+        dir_b = tmp_path / "template_b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        registry.add_or_update(_entry("template_a", dir_a))
+        registry.add_or_update(_entry("template_b", dir_b))
+
+        import shutil
+
+        shutil.rmtree(dir_a)
+
+        entries = registry.list_templates()
+        assert [e["name"] for e in entries] == ["template_b"]
+
+    def test_add_or_update_also_prunes_other_stale_entries(self, tmp_path, registry):
+        dir_a = tmp_path / "template_a"
+        dir_b = tmp_path / "template_b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        registry.add_or_update(_entry("template_a", dir_a))
+
+        import shutil
+
+        shutil.rmtree(dir_a)
+
+        # Adding a new, unrelated entry should also clean up the stale one.
+        registry.add_or_update(_entry("template_b", dir_b))
+
+        entries = registry.list_templates()
+        assert [e["name"] for e in entries] == ["template_b"]
+
+    def test_list_templates_write_failure_still_returns_pruned_view(
+        self, tmp_path, registry, registry_path, monkeypatch
+    ):
+        template_dir = tmp_path / "my_template"
+        template_dir.mkdir()
+        registry.add_or_update(_entry("my_template", template_dir))
+
+        import shutil
+
+        shutil.rmtree(template_dir)
+
+        def _boom(self, entries):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(TemplatesRegistry, "_save_raw", _boom)
+
+        # Should not raise even though persisting the prune fails.
+        assert registry.list_templates() == []


### PR DESCRIPTION
Fixes: #265 

## Changes

* Added a local template registry to track templates downloaded via `fenn pull`.
* Introduced `fenn/dashboard/templates_registry.py` to manage registry persistence and lifecycle.
* Persisted registry entries in `~/.fenn/templates_registry.json`.
* Recorded the following metadata for each pulled template:

  * Template name
  * Local template path
  * Source template
  * Pull timestamp
* Updated `fenn pull` to automatically register templates after a successful download.
* Implemented automatic pruning of registry entries whose local template directories no longer exist.
* Ensured registry write failures do not interrupt `fenn pull`, logging a warning instead.
* Added comprehensive unit tests

## Notes

* The registry serves as the dashboard's source of truth for discovering locally available templates.
* Registry entries are keyed by the resolved absolute template path to prevent duplicate registrations.
* Stale registry entries are automatically removed when their corresponding template directories no longer exist.
* Registry writes are performed atomically to reduce the risk of file corruption.