### PR TITLE
feat(dashboard)[#266]: expose locally downloaded templates in the dashboard

### DIFF
--- a/fenn/dashboard/app.py
+++ b/fenn/dashboard/app.py
@@ -37,6 +37,7 @@ from fenn.dashboard.responses import (
     template_list_unavailable,
     template_not_found,
 )
+from fenn.dashboard.templates_registry import TemplatesRegistry
 from fenn.dashboard.validation import (
     check_body,
     check_non_empty_string,
@@ -83,6 +84,7 @@ app.config.update(
 csrf = CSRFProtect(app)
 
 scanner = FennScanner()
+templates_registry = TemplatesRegistry()
 
 
 class _ApiBadRequest(Exception):
@@ -253,6 +255,19 @@ def session_view(project_name: str, session_id: str) -> str:
     return render_template("session.html", **data)
 
 
+@app.route("/templates")
+def templates_page() -> str:
+    """Return the local templates registry page, listing all templates that have been pulled into a local directory."""
+    entries = templates_registry.list_templates()
+    return render_template(
+        "templates.html",
+        projects=scanner.get_overview()["projects"],
+        templates=entries,
+        total_templates=len(entries),
+        active_page="templates",
+    )
+
+
 @app.route("/api/overview")
 def api_overview() -> Response:
     include_archived = (request.args.get("include_archived") or "").lower() == "true"
@@ -280,6 +295,18 @@ def api_templates() -> tuple[Response, int] | Response:
         {
             "templates": templates,
             "total": len(templates),
+        }
+    )
+
+
+@app.route("/api/templates/local")
+def api_local_templates() -> Response:
+    """Return the templates that have been pulled into a local directory."""
+    entries = templates_registry.list_templates()
+    return jsonify(
+        {
+            "templates": entries,
+            "total": len(entries),
         }
     )
 

--- a/fenn/dashboard/templates/base.html
+++ b/fenn/dashboard/templates/base.html
@@ -35,6 +35,11 @@
         <span class="nav-label">Overview</span>
       </a>
 
+      <a href="/templates" class="nav-item {% if active_page == 'templates' %}active{% endif %}">
+        <span class="nav-icon">▣</span>
+        <span class="nav-label">Templates</span>
+      </a>
+
       {% if projects %}
       <div class="sidebar-section-label" style="margin-top:16px;">Projects</div>
       {% for p in projects %}

--- a/fenn/dashboard/templates/templates.html
+++ b/fenn/dashboard/templates/templates.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+
+{% block title %}Templates — Fenn Dashboard{% endblock %}
+
+{% block breadcrumb %}
+<span class="breadcrumb-current">Templates</span>
+{% endblock %}
+
+{% block content %}
+
+<div class="page-header">
+  <span class="page-tag">// templates</span>
+  <h1 class="page-title">Templates</h1>
+  <p class="page-subtitle">Templates you've downloaded locally with <code>fenn pull</code>.</p>
+</div>
+
+{% if templates %}
+<div class="section-header">
+  <span class="section-title">Downloaded Templates</span>
+</div>
+<div class="search-bar">
+  <input class="search-input form-control" type="text" placeholder="Search templates..." id="template-search" />
+</div>
+
+<div class="card">
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Source</th>
+          <th>Path</th>
+          <th>Pulled</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for t in templates %}
+        <tr data-searchable="{{ t.name }} {{ t.source_template }} {{ t.path }}">
+          <td data-searchable="{{ t.name }}">{{ t.name }}</td>
+          <td class="td-mono" data-searchable="{{ t.source_template }}">{{ t.source_template }}</td>
+          <td class="td-mono" data-searchable="{{ t.path }}" title="{{ t.path }}">{{ t.path }}</td>
+          <td class="td-mono" data-searchable="{{ t.pulled_at }}">{{ t.pulled_at }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+{% else %}
+<div class="empty">
+  <div class="empty-icon">▣</div>
+  <div class="empty-title">No templates downloaded yet</div>
+  <div class="empty-desc">
+    Run <code>fenn pull &lt;template&gt;</code> to download a template — it will
+    show up here once pulled.
+  </div>
+</div>
+{% endif %}
+
+{% endblock %}

--- a/fenn/dashboard/templates_registry.py
+++ b/fenn/dashboard/templates_registry.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 from pathlib import Path
 
 from fenn.dashboard.types import TemplateEntry
@@ -18,6 +19,15 @@ def _default_registry_path() -> Path:
     return Path(
         os.environ.get("FENN_TEMPLATES_REGISTRY_PATH", _DEFAULT_REGISTRY_PATH)
     ).expanduser()
+
+
+def _is_pytest_temp_path(path: Path) -> bool:
+    """Return whether a path looks like a pytest pull-template artifact."""
+    lowered_parts = [part.lower() for part in path.parts]
+    has_pytest_root = any(part.startswith("pytest-of-") for part in lowered_parts)
+    has_pytest_run = any(re.fullmatch(r"pytest-\d+", part) for part in lowered_parts)
+    has_pull_test = any(part.startswith("test_pull_template") for part in lowered_parts)
+    return has_pytest_root and has_pytest_run and has_pull_test
 
 
 class TemplatesRegistry:
@@ -88,7 +98,7 @@ class TemplatesRegistry:
     def _prune_missing(
         entries: dict[str, TemplateEntry],
     ) -> tuple[dict[str, TemplateEntry], bool]:
-        """Drop entries whose directory no longer exists on disk.
+        """Drop entries that are stale or point to pytest temp directories.
 
         Args:
             entries: The registry entries to prune.
@@ -99,7 +109,11 @@ class TemplatesRegistry:
         pruned: dict[str, TemplateEntry] = {}
         changed = False
         for key, entry in entries.items():
-            if Path(entry["path"]).exists():
+            entry_path = Path(entry["path"])
+            if _is_pytest_temp_path(entry_path):
+                changed = True
+                continue
+            if entry_path.exists():
                 pruned[key] = entry
             else:
                 changed = True
@@ -134,6 +148,10 @@ class TemplatesRegistry:
         entries, _ = self._prune_missing(entries)
 
         resolved_path = str(Path(entry["path"]).resolve())
+        if _is_pytest_temp_path(Path(resolved_path)):
+            self._save_raw(entries)
+            return
+
         entries[resolved_path] = TemplateEntry(
             name=entry["name"],
             path=resolved_path,

--- a/fenn/dashboard/types.py
+++ b/fenn/dashboard/types.py
@@ -145,9 +145,20 @@ class SessionListResponse(TypedDict):
 
 
 class TemplateEntry(TypedDict):
-    """A single registered template."""
+    """A single registered template (from the local templates registry)."""
 
     name: str
     path: str
     source_template: str
     pulled_at: str
+
+
+class TemplatesPayload(TypedDict):
+    """GET /templates and GET /api/templates/local — locally downloaded templates."""
+
+    projects: List[ProjectStats]
+
+    templates: List[TemplateEntry]
+    total_templates: int
+
+    active_page: Literal["templates"]

--- a/tests/unit/dashboard/test_api.py
+++ b/tests/unit/dashboard/test_api.py
@@ -1,6 +1,7 @@
 """Unit tests for the /api/sessions endpoint (Pick 3)."""
 
 import re
+import shutil
 import zipfile
 from io import BytesIO
 
@@ -9,6 +10,7 @@ import requests
 
 from fenn.dashboard.app import app
 from fenn.dashboard.scanner import FennScanner
+from fenn.dashboard.templates_registry import TemplateEntry, TemplatesRegistry
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -829,3 +831,200 @@ class TestApiTemplates:
         )
 
         assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Templates page and local templates API
+# ---------------------------------------------------------------------------
+
+
+def _add_template(
+    base_dir,
+    registry,
+    name,
+    source="base",
+    pulled_at="2026-07-21T10:00:00+00:00",
+):
+    template_dir = base_dir / name
+    template_dir.mkdir()
+    registry.add_or_update(
+        TemplateEntry(
+            name=name,
+            path=str(template_dir),
+            source_template=source,
+            pulled_at=pulled_at,
+        )
+    )
+    return template_dir
+
+
+@pytest.fixture()
+def templates_registry_with_entries(tmp_path):
+    """A TemplatesRegistry pre-populated with two locally pulled templates."""
+    registry = TemplatesRegistry(registry_path=tmp_path / "templates_registry.json")
+    _add_template(
+        tmp_path,
+        registry,
+        "tmpl_a",
+        source="base",
+        pulled_at="2026-07-20T10:00:00+00:00",
+    )
+    _add_template(
+        tmp_path,
+        registry,
+        "tmpl_b",
+        source="vision",
+        pulled_at="2026-07-21T10:00:00+00:00",
+    )
+    return registry
+
+
+@pytest.fixture()
+def empty_templates_registry(tmp_path):
+    return TemplatesRegistry(registry_path=tmp_path / "templates_registry.json")
+
+
+@pytest.fixture()
+def templates_client(templates_registry_with_entries):
+    """Flask test client, logged in, wired to a registry with known templates."""
+    import fenn.dashboard.app as app_module
+
+    original = app_module.templates_registry
+    app_module.templates_registry = templates_registry_with_entries
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        with c.session_transaction() as sess:
+            sess["user"] = {"email": "test@example.com"}
+        yield c
+    app_module.templates_registry = original
+
+
+@pytest.fixture()
+def empty_templates_client(empty_templates_registry):
+    """Flask test client, logged in, wired to an empty registry."""
+    import fenn.dashboard.app as app_module
+
+    original = app_module.templates_registry
+    app_module.templates_registry = empty_templates_registry
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        with c.session_transaction() as sess:
+            sess["user"] = {"email": "test@example.com"}
+        yield c
+    app_module.templates_registry = original
+
+
+@pytest.fixture()
+def templates_client_no_auth(templates_registry_with_entries, monkeypatch):
+    """Flask test client wired to a populated registry, but not logged in."""
+    import fenn.dashboard.app as app_module
+
+    monkeypatch.setattr(app_module.token_store, "load", lambda: None)
+    original = app_module.templates_registry
+    app_module.templates_registry = templates_registry_with_entries
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+    app_module.templates_registry = original
+
+
+class TestApiLocalTemplates:
+    def test_returns_registered_templates(self, templates_client):
+        resp = templates_client.get("/api/templates/local")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] == 2
+        names = {t["name"] for t in data["templates"]}
+        assert names == {"tmpl_a", "tmpl_b"}
+
+    def test_response_entry_shape(self, templates_client):
+        resp = templates_client.get("/api/templates/local")
+        entries = resp.get_json()["templates"]
+        [entry] = [e for e in entries if e["name"] == "tmpl_a"]
+        assert set(entry.keys()) == {"name", "path", "source_template", "pulled_at"}
+        assert entry["source_template"] == "base"
+
+    def test_returns_empty_list_when_no_templates_pulled(self, empty_templates_client):
+        resp = empty_templates_client.get("/api/templates/local")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"templates": [], "total": 0}
+
+    def test_deleted_template_directory_is_not_returned(self, templates_client):
+        initial = templates_client.get("/api/templates/local").get_json()
+        tmpl_a_path = next(
+            entry["path"] for entry in initial["templates"] if entry["name"] == "tmpl_a"
+        )
+        shutil.rmtree(tmpl_a_path)
+
+        resp = templates_client.get("/api/templates/local")
+        data = resp.get_json()
+        names = {t["name"] for t in data["templates"]}
+        assert names == {"tmpl_b"}
+        assert data["total"] == 1
+
+    def test_requires_authentication(self, templates_client_no_auth):
+        resp = templates_client_no_auth.get("/api/templates/local")
+        assert resp.status_code == 302
+        assert "/connect" in resp.headers["Location"]
+
+    def test_does_not_collide_with_remote_templates_endpoint(
+        self, templates_client, requests_mock
+    ):
+        """`/api/templates` (remote-available) and `/api/templates/local`
+        (locally downloaded) must stay distinct routes with distinct data."""
+        requests_mock.get(
+            "https://api.github.com/repos/pyfenn/templates/contents",
+            status_code=200,
+            json=[{"name": "base", "type": "dir"}],
+        )
+
+        remote_resp = templates_client.get("/api/templates")
+        local_resp = templates_client.get("/api/templates/local")
+
+        assert remote_resp.status_code == 200
+        assert local_resp.status_code == 200
+        assert remote_resp.get_json()["templates"] == ["base"]
+        assert {t["name"] for t in local_resp.get_json()["templates"]} == {
+            "tmpl_a",
+            "tmpl_b",
+        }
+
+
+class TestTemplatesPage:
+    def test_requires_authentication(self, templates_client_no_auth):
+        resp = templates_client_no_auth.get("/templates")
+        assert resp.status_code == 302
+        assert "/connect" in resp.headers["Location"]
+
+    def test_renders_downloaded_templates(self, templates_client):
+        resp = templates_client.get("/templates")
+        assert resp.status_code == 200
+        assert b"tmpl_a" in resp.data
+        assert b"tmpl_b" in resp.data
+
+    def test_renders_empty_state_when_no_templates(self, empty_templates_client):
+        resp = empty_templates_client.get("/templates")
+        assert resp.status_code == 200
+        assert b"No templates downloaded yet" in resp.data
+
+    def test_does_not_render_deleted_template(self, templates_client):
+        initial = templates_client.get("/api/templates/local").get_json()
+        tmpl_a_path = next(
+            entry["path"] for entry in initial["templates"] if entry["name"] == "tmpl_a"
+        )
+        shutil.rmtree(tmpl_a_path)
+
+        resp = templates_client.get("/templates")
+        assert b"tmpl_a" not in resp.data
+        assert b"tmpl_b" in resp.data
+
+    def test_active_page_marks_nav_item_active(self, templates_client):
+        resp = templates_client.get("/templates")
+        assert b'href="/templates" class="nav-item active"' in resp.data
+
+
+class TestTemplatesNavigation:
+    def test_templates_link_present_on_home_page(self, templates_client):
+        resp = templates_client.get("/")
+        assert resp.status_code == 200
+        assert b'href="/templates"' in resp.data

--- a/tests/unit/dashboard/test_templates_registry.py
+++ b/tests/unit/dashboard/test_templates_registry.py
@@ -262,3 +262,49 @@ class TestPruning:
 
         # Should not raise even though persisting the prune fails.
         assert registry.list_templates() == []
+
+    def test_existing_pytest_temp_entry_is_pruned_even_if_directory_exists(
+        self, tmp_path, registry_path, registry
+    ):
+        pytest_temp_dir = (
+            tmp_path
+            / "pytest-of-user"
+            / "pytest-123"
+            / "test_pull_template_success0"
+            / "downloaded-template"
+        )
+        pytest_temp_dir.mkdir(parents=True)
+
+        registry_path.parent.mkdir(parents=True, exist_ok=True)
+        registry_path.write_text(
+            json.dumps(
+                {
+                    str(pytest_temp_dir.resolve()): {
+                        "name": "downloaded-template",
+                        "path": str(pytest_temp_dir.resolve()),
+                        "source_template": "base",
+                        "pulled_at": "2026-07-21T10:00:00+00:00",
+                    }
+                }
+            )
+        )
+
+        assert registry.list_templates() == []
+        assert json.loads(registry_path.read_text()) == {}
+
+    def test_add_or_update_ignores_pytest_temp_directory(
+        self, tmp_path, registry, registry_path
+    ):
+        pytest_temp_dir = (
+            tmp_path
+            / "pytest-of-user"
+            / "pytest-456"
+            / "test_pull_template_success0"
+            / "downloaded-template"
+        )
+        pytest_temp_dir.mkdir(parents=True)
+
+        registry.add_or_update(_entry("downloaded-template", pytest_temp_dir))
+
+        assert registry.list_templates() == []
+        assert json.loads(registry_path.read_text()) == {}


### PR DESCRIPTION
Fixes: #266 

## Changes
* Implemented `GET /templates` to render the local templates dashboard and `GET /api/templates/local` to expose locally downloaded templates via the API.
* Added `TemplateEntry` and `TemplatesPayload` types for the local templates page and API.
* Created `templates.html` to display downloaded templates, including search support and an empty state.
* Added a **Templates** entry to the dashboard navigation in `base.html`.
* Added comprehensive dashboard units tests for the same.

## Notes
* While testing, I noticed that tmp directories created by pytest were appearing on the Templates page. To prevent test artifacts from being surfaced in the dashboard, I enhanced `templates_registry.py` to automatically prune temporary pytest pull-template directories from the registry.