### PR TITLE
feat(dashboard)[#267]: Add reusable template runner and `POST /api/templates/run` for launching downloaded templates

### DIFF
--- a/fenn/dashboard/app.py
+++ b/fenn/dashboard/app.py
@@ -34,9 +34,12 @@ from fenn.dashboard.responses import (
     invalid_template,
     target_not_empty,
     template_download_unavailable,
+    template_launch_failed,
     template_list_unavailable,
     template_not_found,
+    template_not_registered,
 )
+from fenn.dashboard.runner import TemplateLaunchError, TemplateRunner
 from fenn.dashboard.templates_registry import TemplatesRegistry
 from fenn.dashboard.validation import (
     check_body,
@@ -85,6 +88,7 @@ csrf = CSRFProtect(app)
 
 scanner = FennScanner()
 templates_registry = TemplatesRegistry()
+template_runner = TemplateRunner()
 
 
 class _ApiBadRequest(Exception):
@@ -377,6 +381,49 @@ def api_template_pull() -> tuple[Response, int] | Response:
             "template": template_name.strip(),
             "path": str(resolved_path),
             "downloaded": True,
+        }
+    )
+
+
+@app.route("/api/templates/run", methods=["POST"])
+def api_template_run() -> tuple[Response, int] | Response:
+    """Launch a locally downloaded template as a background process."""
+    payload = request.get_json(silent=True)
+
+    if (error := check_body(payload, dict)) is not None:
+        return error
+
+    assert isinstance(payload, dict)
+
+    template_path = payload.get("path")
+
+    if (error := check_non_empty_string(template_path, "path")) is not None:
+        return error
+
+    assert isinstance(template_path, str)
+
+    resolved_path = str(Path(template_path).resolve())
+    registered_paths = {entry["path"] for entry in templates_registry.list_templates()}
+    if resolved_path not in registered_paths:
+        return (
+            template_not_registered(
+                f"{template_path} is not a locally registered template"
+            ),
+            404,
+        )
+
+    try:
+        running = template_runner.launch(Path(template_path), scanner=scanner)
+    except TemplateLaunchError as exc:
+        return template_launch_failed(exc), 502
+
+    return jsonify(
+        {
+            "run_id": running.run_id,
+            "template_path": str(running.template_path),
+            "log_dir": str(running.log_dir),
+            "pid": running.process.pid,
+            "launched": True,
         }
     )
 

--- a/fenn/dashboard/responses.py
+++ b/fenn/dashboard/responses.py
@@ -85,3 +85,19 @@ def filesystem_error(exc: Exception) -> Response:
         message=str(exc),
         param="path",
     )
+
+
+def template_not_registered(exc: Exception | str) -> Response:
+    return error_response(
+        code="template_not_registered",
+        message=str(exc),
+        param="path",
+    )
+
+
+def template_launch_failed(exc: Exception) -> Response:
+    return error_response(
+        code="template_launch_failed",
+        message=str(exc),
+        param="path",
+    )

--- a/fenn/dashboard/runner.py
+++ b/fenn/dashboard/runner.py
@@ -1,0 +1,180 @@
+"""Launch downloaded templates as background processes and track them."""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from fenn.dashboard.scanner import FennScanner
+
+# Grace period to catch immediate startup failures (missing deps, syntax
+# errors, bad imports) before handing control back to the caller. These
+# crashes happen before any .fn log file exists, so the scanner alone can't
+# surface them — we have to watch the process directly for a short window.
+_DEFAULT_STARTUP_GRACE_S = 0.75
+
+_DEFAULT_ENTRYPOINT = "main.py"
+_FENN_YAML_NAME = "fenn.yaml"
+_DEFAULT_LOGGER_DIR = "logger"
+_STDERR_TRUNCATE = 500
+
+
+class TemplateLaunchError(Exception):
+    """Raised when a template cannot be launched or fails during startup."""
+
+
+@dataclass
+class RunningTemplate:
+    """A tracked, launched template process."""
+
+    run_id: str
+    template_path: Path
+    log_dir: Path
+    process: subprocess.Popen
+    started_at: float
+
+    def poll(self) -> Optional[int]:
+        """Return the exit code if the process has finished, else None."""
+        return self.process.poll()
+
+
+class TemplateRunner:
+    """Launches templates via subprocess.Popen and tracks active processes."""
+
+    def __init__(self, startup_grace_s: float = _DEFAULT_STARTUP_GRACE_S) -> None:
+        self._lock = threading.Lock()
+        self._active: dict[str, RunningTemplate] = {}
+        self._startup_grace_s = startup_grace_s
+
+    # ------------------------------------------------------------------
+    # Config
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _read_logger_dir(template_path: Path) -> Path:
+        """Read logger.dir from fenn.yaml, resolved relative to the template.
+
+        Falls back to "logger" if the key is absent, matching the shipped
+        template default.
+        """
+        yaml_path = template_path / _FENN_YAML_NAME
+        if not yaml_path.exists():
+            raise TemplateLaunchError(f"{_FENN_YAML_NAME} not found in {template_path}")
+
+        try:
+            content = yaml_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise TemplateLaunchError(
+                f"Could not read {_FENN_YAML_NAME}: {exc}"
+            ) from exc
+
+        try:
+            data = yaml.safe_load(content)
+        except yaml.YAMLError as exc:
+            raise TemplateLaunchError(f"Invalid {_FENN_YAML_NAME}: {exc}") from exc
+
+        if not isinstance(data, dict):
+            raise TemplateLaunchError(f"{_FENN_YAML_NAME} must contain a mapping")
+
+        logger_cfg = data.get("logger")
+        raw_dir = _DEFAULT_LOGGER_DIR
+        if isinstance(logger_cfg, dict):
+            configured = logger_cfg.get("dir")
+            if isinstance(configured, str) and configured.strip():
+                raw_dir = configured.strip()
+
+        return (template_path / raw_dir).resolve()
+
+    # ------------------------------------------------------------------
+    # Launch
+    # ------------------------------------------------------------------
+
+    def launch(
+        self,
+        template_path: Path,
+        scanner: FennScanner,
+        entrypoint: str = _DEFAULT_ENTRYPOINT,
+    ) -> RunningTemplate:
+        """Launch a template's entrypoint and register its log directory.
+
+        Raises TemplateLaunchError if the template path is invalid, the
+        entrypoint is missing, or the process exits within the startup
+        grace period (treated as a startup failure).
+        """
+        template_path = template_path.resolve()
+        if not template_path.is_dir():
+            raise TemplateLaunchError(
+                f"Template path is not a directory: {template_path}"
+            )
+
+        entry_path = template_path / entrypoint
+        if not entry_path.exists():
+            raise TemplateLaunchError(
+                f"Entrypoint {entrypoint!r} not found in {template_path}"
+            )
+
+        log_dir = self._read_logger_dir(template_path)
+
+        try:
+            process = subprocess.Popen(
+                ["python", str(entry_path)],
+                cwd=str(template_path),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except OSError as exc:
+            raise TemplateLaunchError(f"Failed to start process: {exc}") from exc
+
+        # Watch for a fast crash before any .fn log would exist.
+        if self._startup_grace_s > 0:
+            time.sleep(self._startup_grace_s)
+        exit_code = process.poll()
+        if exit_code is not None and exit_code != 0:
+            _, stderr = process.communicate()
+            raise TemplateLaunchError(
+                f"Template exited immediately with code {exit_code}: "
+                f"{(stderr or '').strip()[:_STDERR_TRUNCATE]}"
+            )
+
+        # Register the log directory only after confirming the process is
+        # actually alive, so the scanner never picks up a directory for a
+        # template that never started.
+        scanner.add_dirs([str(log_dir)])
+
+        run_id = uuid.uuid4().hex
+        running = RunningTemplate(
+            run_id=run_id,
+            template_path=template_path,
+            log_dir=log_dir,
+            process=process,
+            started_at=time.time(),
+        )
+        with self._lock:
+            self._active[run_id] = running
+        return running
+
+    # ------------------------------------------------------------------
+    # Tracking
+    # ------------------------------------------------------------------
+
+    def get(self, run_id: str) -> Optional[RunningTemplate]:
+        with self._lock:
+            return self._active.get(run_id)
+
+    def list_active(self) -> list[RunningTemplate]:
+        """Return all tracked processes, pruning any that have since exited."""
+        with self._lock:
+            finished = [
+                rid for rid, rt in self._active.items() if rt.poll() is not None
+            ]
+            for rid in finished:
+                del self._active[rid]
+            return list(self._active.values())

--- a/fenn/dashboard/types.py
+++ b/fenn/dashboard/types.py
@@ -162,3 +162,13 @@ class TemplatesPayload(TypedDict):
     total_templates: int
 
     active_page: Literal["templates"]
+
+
+class TemplateRunResponse(TypedDict):
+    """POST /api/templates/run — successful launch response."""
+
+    run_id: str
+    template_path: str
+    log_dir: str
+    pid: int
+    launched: Literal[True]

--- a/tests/unit/dashboard/test_api.py
+++ b/tests/unit/dashboard/test_api.py
@@ -9,6 +9,7 @@ import pytest
 import requests
 
 from fenn.dashboard.app import app
+from fenn.dashboard.runner import RunningTemplate, TemplateLaunchError
 from fenn.dashboard.scanner import FennScanner
 from fenn.dashboard.templates_registry import TemplateEntry, TemplatesRegistry
 
@@ -1028,3 +1029,106 @@ class TestTemplatesNavigation:
         resp = templates_client.get("/")
         assert resp.status_code == 200
         assert b'href="/templates"' in resp.data
+
+
+class TestApiTemplateRun:
+    """Tests for POST /api/templates/run."""
+
+    def test_run_rejects_unregistered_path(self, templates_client, tmp_path):
+        token = _extract_csrf_token(templates_client.get("/").get_data(as_text=True))
+        resp = templates_client.post(
+            "/api/templates/run",
+            json={"path": str(tmp_path / "not-registered")},
+            headers={"X-CSRFToken": token},
+        )
+        assert resp.status_code == 404
+        body = resp.get_json()
+        assert body["error"]["code"] == "template_not_registered"
+        assert body["error"]["param"] == "path"
+
+    def test_run_rejects_invalid_payload(self, templates_client):
+        token = _extract_csrf_token(templates_client.get("/").get_data(as_text=True))
+        resp = templates_client.post(
+            "/api/templates/run",
+            json={"path": ""},
+            headers={"X-CSRFToken": token},
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["error"]["param"] == "path"
+
+    def test_run_requires_csrf(self, templates_client, tmp_path):
+        resp = templates_client.post(
+            "/api/templates/run",
+            json={"path": str(tmp_path)},
+        )
+        assert resp.status_code == 400
+
+    def test_run_requires_authentication(self, templates_client_no_auth, tmp_path):
+        token = _extract_csrf_token(
+            templates_client_no_auth.get("/connect").get_data(as_text=True)
+        )
+        resp = templates_client_no_auth.post(
+            "/api/templates/run",
+            json={"path": str(tmp_path)},
+            headers={"X-CSRFToken": token},
+        )
+        assert resp.status_code == 302
+        assert "/connect" in resp.headers["Location"]
+
+    def test_run_success_launches_and_returns_payload(
+        self, templates_client, templates_registry_with_entries, monkeypatch
+    ):
+        import fenn.dashboard.app as app_module
+
+        entries = templates_registry_with_entries.list_templates()
+        target = entries[0]["path"]
+
+        fake_process = type(
+            "FakeProcess", (), {"pid": 4242, "poll": lambda self: None}
+        )()
+        fake_running = RunningTemplate(
+            run_id="abc123",
+            template_path=app_module.Path(target),
+            log_dir=app_module.Path(target) / "logger",
+            process=fake_process,
+            started_at=0.0,
+        )
+        monkeypatch.setattr(
+            app_module.template_runner, "launch", lambda *a, **k: fake_running
+        )
+
+        token = _extract_csrf_token(templates_client.get("/").get_data(as_text=True))
+        resp = templates_client.post(
+            "/api/templates/run",
+            json={"path": target},
+            headers={"X-CSRFToken": token},
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["run_id"] == "abc123"
+        assert body["pid"] == 4242
+        assert body["launched"] is True
+
+    def test_run_launch_failure_returns_502(
+        self, templates_client, templates_registry_with_entries, monkeypatch
+    ):
+        import fenn.dashboard.app as app_module
+
+        entries = templates_registry_with_entries.list_templates()
+        target = entries[0]["path"]
+
+        def _raise(*a, **k):
+            raise TemplateLaunchError("boom: crashed on startup")
+
+        monkeypatch.setattr(app_module.template_runner, "launch", _raise)
+
+        token = _extract_csrf_token(templates_client.get("/").get_data(as_text=True))
+        resp = templates_client.post(
+            "/api/templates/run",
+            json={"path": target},
+            headers={"X-CSRFToken": token},
+        )
+        assert resp.status_code == 502
+        body = resp.get_json()
+        assert body["error"]["code"] == "template_launch_failed"
+        assert "boom: crashed on startup" in body["error"]["message"]

--- a/tests/unit/dashboard/test_runner.py
+++ b/tests/unit/dashboard/test_runner.py
@@ -1,0 +1,141 @@
+"""Unit tests for TemplateRunner."""
+
+import textwrap
+
+import pytest
+
+from fenn.dashboard.runner import TemplateLaunchError, TemplateRunner
+from fenn.dashboard.scanner import FennScanner
+
+
+def _write_template(tmp_path, entrypoint_body, fenn_yaml=None, entrypoint="main.py"):
+    (tmp_path / entrypoint).write_text(
+        textwrap.dedent(entrypoint_body), encoding="utf-8"
+    )
+    if fenn_yaml is not None:
+        (tmp_path / "fenn.yaml").write_text(
+            textwrap.dedent(fenn_yaml), encoding="utf-8"
+        )
+    return tmp_path
+
+
+@pytest.fixture()
+def scanner(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "FENN_DASHBOARD_OVERRIDES_PATH", str(tmp_path / "overrides.json")
+    )
+    return FennScanner(extra_dirs=[])
+
+
+@pytest.fixture()
+def runner():
+    # Tiny grace period keeps unit tests fast.
+    return TemplateRunner(startup_grace_s=0.1)
+
+
+class TestReadLoggerDir:
+    def test_reads_configured_dir(self, tmp_path):
+        _write_template(
+            tmp_path,
+            "import time\ntime.sleep(5)\n",
+            fenn_yaml="logger:\n  dir: custom_logs\n",
+        )
+        runner_ = TemplateRunner()
+        log_dir = runner_._read_logger_dir(tmp_path)
+        assert log_dir == (tmp_path / "custom_logs").resolve()
+
+    def test_defaults_when_key_missing(self, tmp_path):
+        _write_template(tmp_path, "pass\n", fenn_yaml="project: test\n")
+        runner_ = TemplateRunner()
+        log_dir = runner_._read_logger_dir(tmp_path)
+        assert log_dir == (tmp_path / "logger").resolve()
+
+    def test_missing_fenn_yaml_raises(self, tmp_path):
+        _write_template(tmp_path, "pass\n", fenn_yaml=None)
+        runner_ = TemplateRunner()
+        with pytest.raises(TemplateLaunchError, match="fenn.yaml"):
+            runner_._read_logger_dir(tmp_path)
+
+    def test_invalid_yaml_raises(self, tmp_path):
+        _write_template(tmp_path, "pass\n", fenn_yaml="logger: [unterminated\n")
+        runner_ = TemplateRunner()
+        with pytest.raises(TemplateLaunchError, match="Invalid fenn.yaml"):
+            runner_._read_logger_dir(tmp_path)
+
+
+class TestLaunch:
+    def test_launch_success_registers_log_dir(self, tmp_path, scanner, runner):
+        _write_template(
+            tmp_path,
+            """
+            import time
+            time.sleep(2)
+            """,
+            fenn_yaml="logger:\n  dir: logs\n",
+        )
+        running = runner.launch(tmp_path, scanner=scanner)
+        try:
+            assert running.log_dir == (tmp_path / "logs").resolve()
+            assert running.log_dir in scanner._dirs
+            assert running.process.poll() is None
+            assert runner.get(running.run_id) is running
+        finally:
+            running.process.kill()
+            running.process.wait()
+
+    def test_missing_directory_raises(self, tmp_path, scanner, runner):
+        with pytest.raises(TemplateLaunchError, match="not a directory"):
+            runner.launch(tmp_path / "nope", scanner=scanner)
+
+    def test_missing_entrypoint_raises(self, tmp_path, scanner, runner):
+        (tmp_path / "fenn.yaml").write_text("logger:\n  dir: logs\n", encoding="utf-8")
+        with pytest.raises(TemplateLaunchError, match="Entrypoint"):
+            runner.launch(tmp_path, scanner=scanner)
+
+    def test_immediate_crash_raises_with_stderr(self, tmp_path, scanner, runner):
+        _write_template(
+            tmp_path,
+            """
+            import sys
+            sys.stderr.write("boom: bad config\\n")
+            sys.exit(1)
+            """,
+            fenn_yaml="logger:\n  dir: logs\n",
+        )
+        with pytest.raises(TemplateLaunchError, match="boom: bad config"):
+            runner.launch(tmp_path, scanner=scanner)
+
+    def test_crash_does_not_register_log_dir(self, tmp_path, scanner, runner):
+        _write_template(
+            tmp_path,
+            "import sys\nsys.exit(1)\n",
+            fenn_yaml="logger:\n  dir: logs\n",
+        )
+        with pytest.raises(TemplateLaunchError):
+            runner.launch(tmp_path, scanner=scanner)
+        assert (tmp_path / "logs").resolve() not in scanner._dirs
+
+    def test_successful_exit_zero_within_grace_still_registers(
+        self, tmp_path, scanner, runner
+    ):
+        _write_template(
+            tmp_path,
+            "pass\n",
+            fenn_yaml="logger:\n  dir: logs\n",
+        )
+        running = runner.launch(tmp_path, scanner=scanner)
+        assert running.log_dir in scanner._dirs
+
+
+class TestListActive:
+    def test_list_active_prunes_finished(self, tmp_path, scanner, runner):
+        _write_template(
+            tmp_path,
+            "import time\ntime.sleep(2)\n",
+            fenn_yaml="logger:\n  dir: logs\n",
+        )
+        running = runner.launch(tmp_path, scanner=scanner)
+        assert running in runner.list_active()
+        running.process.kill()
+        running.process.wait()
+        assert running.run_id not in {r.run_id for r in runner.list_active()}

--- a/tests/unit/dashboard/test_scanner_cache.py
+++ b/tests/unit/dashboard/test_scanner_cache.py
@@ -1,5 +1,6 @@
 """Unit tests for FennScanner caching (Pick 2) and running-session detection."""
 
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -77,6 +78,8 @@ class TestParseCache:
         # Rewrite with different content (changes mtime on real FS)
         updated = _COMPLETED_FN.format(sid="s1").replace("hello", "world")
         fn.write_text(updated, encoding="utf-8")
+        new_mtime = fn.stat().st_mtime + 1
+        os.utime(fn, (new_mtime, new_mtime))
 
         result = scanner.parse_fn_file(fn)
 


### PR DESCRIPTION
Fixes: #267

## Changes
* Created `fenn/dashboard/runner.py` with a `TemplateRunner` class that launches templates via `subprocess.Popen`, tracks active processes, and detects early startup failures (non-zero exit within a short grace window) before any `.fn` log file would exist.
* `TemplateRunner` reads `logger.dir` from the template's `fenn.yaml` (falling back to `logger` if unset) and dynamically registers the resolved log directory with `FennScanner.add_dirs`, so newly launched sessions appear in the existing session viewer without a dashboard restart.
* Implemented `POST /api/templates/run` in `app.py` — validates the request body, confirms the requested path matches a locally registered template (via `TemplatesRegistry`), and returns a consistent JSON envelope (`run_id`, `template_path`, `log_dir`, `pid`, `launched`) on success.
* Added `template_not_registered` and `template_launch_failed` error responses in `responses.py`, and a `TemplateRunResponse` type in `types.py`, following existing response/type conventions.
* Added `TemplateLaunchError` for invalid template paths, missing entrypoints, unreadable/invalid `fenn.yaml`, and immediate process crashes (surfaces truncated stderr).
* Added `tests/unit/dashboard/test_runner.py` covering `logger.dir` resolution, successful launch + scanner registration, missing directory/entrypoint, immediate-crash handling, and active-process tracking/pruning.
* Added `TestApiTemplateRun` to `test_api.py` covering payload validation, CSRF enforcement, auth enforcement, successful launch response shape, and 502 on launch failure.

## Notes
* Launching is currently gated to templates already present in `TemplatesRegistry` (i.e. pulled via `/api/templates/pull`) — arbitrary filesystem paths are rejected with `template_not_registered`. Open to revisiting if templates should be launchable from any path.
* The startup-failure grace window is a fixed short sleep (`_DEFAULT_STARTUP_GRACE_S`); it catches immediate crashes (bad imports, syntax errors) but won't catch failures that occur after that window — those will still be visible once the session's `.fn` file appears, just not surfaced synchronously in the API response.
* Fixed one unrelated test issue surfaced while running the full dashboard suite: `test_mtime_change_invalidates_cache` now force-bumps mtime via `os.utime` instead of relying on wall-clock write timing, which was flaky on filesystems with coarse mtime resolution.