### PR TITLE
feat(dashboard)[#268]: add `Run` button to templates dashboard: launch, poll, and redirect to live session

### DIFF
--- a/fenn/dashboard/app.py
+++ b/fenn/dashboard/app.py
@@ -41,7 +41,7 @@ from fenn.dashboard.responses import (
 )
 from fenn.dashboard.runner import TemplateLaunchError, TemplateRunner
 from fenn.dashboard.templates_registry import TemplatesRegistry
-from fenn.dashboard.types import SessionData
+from fenn.dashboard.types import SessionData, TemplateRunResponse, TemplatesPayload
 from fenn.dashboard.validation import (
     check_body,
     check_non_empty_string,
@@ -308,12 +308,13 @@ def api_templates() -> tuple[Response, int] | Response:
 def api_local_templates() -> Response:
     """Return the templates that have been pulled into a local directory."""
     entries = templates_registry.list_templates()
-    return jsonify(
-        {
-            "templates": entries,
-            "total": len(entries),
-        }
-    )
+    payload: TemplatesPayload = {
+        "projects": scanner.get_overview()["projects"],
+        "templates": entries,
+        "total_templates": len(entries),
+        "active_page": "templates",
+    }
+    return jsonify(payload)
 
 
 @app.route("/api/templates/pull", methods=["POST"])
@@ -418,15 +419,14 @@ def api_template_run() -> tuple[Response, int] | Response:
     except TemplateLaunchError as exc:
         return template_launch_failed(exc), 502
 
-    return jsonify(
-        {
-            "run_id": running.run_id,
-            "template_path": str(running.template_path),
-            "log_dir": str(running.log_dir),
-            "pid": running.process.pid,
-            "launched": True,
-        }
-    )
+    response: TemplateRunResponse = {
+        "run_id": running.run_id,
+        "template_path": str(running.template_path),
+        "log_dir": str(running.log_dir),
+        "pid": running.process.pid,
+        "launched": True,
+    }
+    return jsonify(response)
 
 
 @app.route("/api/templates/run/<run_id>/status")

--- a/fenn/dashboard/app.py
+++ b/fenn/dashboard/app.py
@@ -41,6 +41,7 @@ from fenn.dashboard.responses import (
 )
 from fenn.dashboard.runner import TemplateLaunchError, TemplateRunner
 from fenn.dashboard.templates_registry import TemplatesRegistry
+from fenn.dashboard.types import SessionData
 from fenn.dashboard.validation import (
     check_body,
     check_non_empty_string,
@@ -426,6 +427,70 @@ def api_template_run() -> tuple[Response, int] | Response:
             "launched": True,
         }
     )
+
+
+@app.route("/api/templates/run/<run_id>/status")
+def api_template_run_status(run_id: str) -> tuple[Response, int] | Response:
+    """Poll launch status for a run started via /api/templates/run.
+
+    Returns one of:
+      {"status": "pending"}                                   — still starting
+      {"status": "found", "project": ..., "session_id": ...}   — session located
+      {"status": "failed", "exit_code": ..., "error": "..."}   — process died first
+    """
+    running = template_runner.get(run_id)
+    if running is None:
+        return (
+            jsonify(
+                {
+                    "error": {
+                        "code": "run_not_found",
+                        "message": "Unknown or expired run_id",
+                    }
+                }
+            ),
+            404,
+        )
+
+    exit_code = running.poll()
+    if exit_code is not None and exit_code != 0:
+        stderr = ""
+        try:
+            _, stderr = running.process.communicate(timeout=0.1)
+        except Exception:
+            pass
+        return jsonify(
+            {
+                "status": "failed",
+                "exit_code": exit_code,
+                "error": (stderr or "").strip()[:500],
+            }
+        )
+
+    log_dir = running.log_dir
+    match: SessionData | None = None
+    for s in scanner.get_all_sessions(include_archived=True):
+        try:
+            file_path = Path(s["file_path"]).resolve()
+        except OSError:
+            continue
+        if not file_path.is_relative_to(log_dir):
+            continue
+        if s["file_mtime"] < running.started_at:
+            continue
+        if match is None or s["file_mtime"] > match["file_mtime"]:
+            match = s
+
+    if match is not None:
+        return jsonify(
+            {
+                "status": "found",
+                "project": match["project"],
+                "session_id": match["session_id"],
+            }
+        )
+
+    return jsonify({"status": "pending"})
 
 
 @app.route("/api/session/<project_name>/<session_id>/rename", methods=["POST"])

--- a/fenn/dashboard/app.py
+++ b/fenn/dashboard/app.py
@@ -41,7 +41,7 @@ from fenn.dashboard.responses import (
 )
 from fenn.dashboard.runner import TemplateLaunchError, TemplateRunner
 from fenn.dashboard.templates_registry import TemplatesRegistry
-from fenn.dashboard.types import SessionData, TemplateRunResponse, TemplatesPayload
+from fenn.dashboard.types import TemplateRunResponse, TemplatesPayload
 from fenn.dashboard.validation import (
     check_body,
     check_non_empty_string,
@@ -467,19 +467,7 @@ def api_template_run_status(run_id: str) -> tuple[Response, int] | Response:
             }
         )
 
-    log_dir = running.log_dir
-    match: SessionData | None = None
-    for s in scanner.get_all_sessions(include_archived=True):
-        try:
-            file_path = Path(s["file_path"]).resolve()
-        except OSError:
-            continue
-        if not file_path.is_relative_to(log_dir):
-            continue
-        if s["file_mtime"] < running.started_at:
-            continue
-        if match is None or s["file_mtime"] > match["file_mtime"]:
-            match = s
+    match = scanner.find_matching_session(running.log_dir, running.started_at)
 
     if match is not None:
         return jsonify(

--- a/fenn/dashboard/runner.py
+++ b/fenn/dashboard/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 import threading
 import time
 import uuid
@@ -124,7 +125,7 @@ class TemplateRunner:
 
         try:
             process = subprocess.Popen(
-                ["python", str(entry_path)],
+                [sys.executable, str(entry_path)],
                 cwd=str(template_path),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -134,8 +135,10 @@ class TemplateRunner:
             raise TemplateLaunchError(f"Failed to start process: {exc}") from exc
 
         # Watch for a fast crash before any .fn log would exist.
-        if self._startup_grace_s > 0:
-            time.sleep(self._startup_grace_s)
+        try:
+            process.wait(timeout=self._startup_grace_s)
+        except subprocess.TimeoutExpired:
+            pass
         exit_code = process.poll()
         if exit_code is not None and exit_code != 0:
             _, stderr = process.communicate()

--- a/fenn/dashboard/scanner.py
+++ b/fenn/dashboard/scanner.py
@@ -417,6 +417,24 @@ class FennScanner:
                 sessions.append(session)
         return sessions
 
+    def find_matching_session(
+        self, log_dir: Path, started_at: float
+    ) -> SessionData | None:
+        """Find newest session under log_dir with mtime >= started_at."""
+        match: SessionData | None = None
+        for s in self.get_all_sessions(include_archived=True):
+            try:
+                file_path = Path(s["file_path"]).resolve()
+            except OSError:
+                continue
+            if not file_path.is_relative_to(log_dir):
+                continue
+            if s["file_mtime"] < started_at:
+                continue
+            if match is None or s["file_mtime"] > match["file_mtime"]:
+                match = s
+        return match
+
     @staticmethod
     def _build_projects_list(sessions: list[SessionData]) -> list[ProjectStats]:
         """Aggregate per-project stats from an already-loaded sessions list."""

--- a/fenn/dashboard/static/app.js
+++ b/fenn/dashboard/static/app.js
@@ -262,6 +262,69 @@
     });
   }
 
+  // ── Template run actions (templates page) ──────────────────────────────── //
+
+  const RUN_POLL_INTERVAL_MS = 1000;
+  const RUN_POLL_TIMEOUT_MS  = 30000;
+
+  function setRunFeedback(btn, message, isError) {
+    const feedback = btn.parentElement?.querySelector(".template-run-feedback");
+    if (!feedback) return;
+    feedback.textContent = message || "";
+    feedback.style.color = isError ? "#c0392b" : "";
+  }
+
+  function pollRunStatus(runId, btn, deadline) {
+    if (Date.now() > deadline) {
+      setRunFeedback(btn, "Still starting — check back shortly.", true);
+      btn.disabled = false;
+      return;
+    }
+
+    fetch(`/api/templates/run/${encodeURIComponent(runId)}/status`)
+      .then((r) => r.json())
+      .then((body) => {
+        if (body.status === "found") {
+          window.location.href = `/session/${encodeURIComponent(body.project)}/${encodeURIComponent(body.session_id)}`;
+          return;
+        }
+        if (body.status === "failed") {
+          setRunFeedback(btn, body.error || "Template failed to start.", true);
+          btn.disabled = false;
+          return;
+        }
+        setTimeout(() => pollRunStatus(runId, btn, deadline), RUN_POLL_INTERVAL_MS);
+      })
+      .catch(() => {
+        setTimeout(() => pollRunStatus(runId, btn, deadline), RUN_POLL_INTERVAL_MS);
+      });
+  }
+
+  document.querySelectorAll(".template-run-btn").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      const path = btn.dataset.path;
+      if (!path) return;
+
+      btn.disabled = true;
+      setRunFeedback(btn, "Launching…", false);
+
+      try {
+        const resp = await postJson("/api/templates/run", { path });
+        const body = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+          setRunFeedback(btn, body?.error?.message || "Failed to launch template.", true);
+          btn.disabled = false;
+          return;
+        }
+        setRunFeedback(btn, "Starting…", false);
+        pollRunStatus(body.run_id, btn, Date.now() + RUN_POLL_TIMEOUT_MS);
+      } catch (_err) {
+        setRunFeedback(btn, "Failed to launch template.", true);
+        btn.disabled = false;
+      }
+    });
+  });
+
   // ── Session search (index page) ────────────────────────────────────────── //
 
   const sessionSearch = document.getElementById("session-search");

--- a/fenn/dashboard/templates/templates.html
+++ b/fenn/dashboard/templates/templates.html
@@ -11,7 +11,7 @@
 <div class="page-header">
   <span class="page-tag">// templates</span>
   <h1 class="page-title">Templates</h1>
-  <p class="page-subtitle">Templates you've downloaded locally with <code>fenn pull</code>.</p>
+  <p class="page-subtitle">Templates you've downloaded locally with <code>fenn pull</code> — click Run to launch one and jump straight to its live session.</p>
 </div>
 
 {% if templates %}
@@ -31,6 +31,7 @@
           <th>Source</th>
           <th>Path</th>
           <th>Pulled</th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -40,6 +41,10 @@
           <td class="td-mono" data-searchable="{{ t.source_template }}">{{ t.source_template }}</td>
           <td class="td-mono" data-searchable="{{ t.path }}" title="{{ t.path }}">{{ t.path }}</td>
           <td class="td-mono" data-searchable="{{ t.pulled_at }}">{{ t.pulled_at }}</td>
+          <td class="td-actions">
+            <button type="button" class="btn template-run-btn" data-path="{{ t.path }}" data-name="{{ t.name }}">Run</button>
+            <div class="template-run-feedback" aria-live="polite"></div>
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/fenn/dashboard/templates_registry.py
+++ b/fenn/dashboard/templates_registry.py
@@ -26,7 +26,7 @@ def _is_pytest_temp_path(path: Path) -> bool:
     lowered_parts = [part.lower() for part in path.parts]
     has_pytest_root = any(part.startswith("pytest-of-") for part in lowered_parts)
     has_pytest_run = any(re.fullmatch(r"pytest-\d+", part) for part in lowered_parts)
-    has_pull_test = any(part.startswith("test_pull_template") for part in lowered_parts)
+    has_pull_test = any(part.startswith("test_pull") for part in lowered_parts)
     return has_pytest_root and has_pytest_run and has_pull_test
 
 

--- a/tests/unit/dashboard/test_api.py
+++ b/tests/unit/dashboard/test_api.py
@@ -934,7 +934,7 @@ class TestApiLocalTemplates:
         resp = templates_client.get("/api/templates/local")
         assert resp.status_code == 200
         data = resp.get_json()
-        assert data["total"] == 2
+        assert data["total_templates"] == 2
         names = {t["name"] for t in data["templates"]}
         assert names == {"tmpl_a", "tmpl_b"}
 
@@ -948,7 +948,9 @@ class TestApiLocalTemplates:
     def test_returns_empty_list_when_no_templates_pulled(self, empty_templates_client):
         resp = empty_templates_client.get("/api/templates/local")
         assert resp.status_code == 200
-        assert resp.get_json() == {"templates": [], "total": 0}
+        data = resp.get_json()
+        assert data["templates"] == []
+        assert data["total_templates"] == 0
 
     def test_deleted_template_directory_is_not_returned(self, templates_client):
         initial = templates_client.get("/api/templates/local").get_json()
@@ -961,7 +963,7 @@ class TestApiLocalTemplates:
         data = resp.get_json()
         names = {t["name"] for t in data["templates"]}
         assert names == {"tmpl_b"}
-        assert data["total"] == 1
+        assert data["total_templates"] == 1
 
     def test_requires_authentication(self, templates_client_no_auth):
         resp = templates_client_no_auth.get("/api/templates/local")

--- a/tests/unit/dashboard/test_api.py
+++ b/tests/unit/dashboard/test_api.py
@@ -1132,3 +1132,171 @@ class TestApiTemplateRun:
         body = resp.get_json()
         assert body["error"]["code"] == "template_launch_failed"
         assert "boom: crashed on startup" in body["error"]["message"]
+
+
+class TestApiTemplateRunStatus:
+    """Tests for GET /api/templates/run/<run_id>/status."""
+
+    def test_unknown_run_id_returns_404(self, templates_client):
+        resp = templates_client.get("/api/templates/run/nope/status")
+        assert resp.status_code == 404
+        assert resp.get_json()["error"]["code"] == "run_not_found"
+
+    def test_pending_when_no_matching_session_yet(
+        self, templates_client, templates_registry_with_entries, monkeypatch, tmp_path
+    ):
+        import fenn.dashboard.app as app_module
+
+        target = templates_registry_with_entries.list_templates()[0]["path"]
+        fake_process = type("FakeProcess", (), {"pid": 1, "poll": lambda self: None})()
+        fake_running = RunningTemplate(
+            run_id="run1",
+            template_path=app_module.Path(target),
+            log_dir=tmp_path / "logger",
+            process=fake_process,
+            started_at=0.0,
+        )
+        monkeypatch.setattr(app_module.template_runner, "get", lambda rid: fake_running)
+        monkeypatch.setattr(
+            app_module.scanner, "get_all_sessions", lambda include_archived=True: []
+        )
+
+        resp = templates_client.get("/api/templates/run/run1/status")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "pending"
+
+    def test_found_when_session_appears_in_log_dir(
+        self, templates_client, templates_registry_with_entries, monkeypatch, tmp_path
+    ):
+        import fenn.dashboard.app as app_module
+
+        log_dir = tmp_path / "logger"
+        log_dir.mkdir()
+        target = templates_registry_with_entries.list_templates()[0]["path"]
+        fake_process = type("FakeProcess", (), {"pid": 1, "poll": lambda self: None})()
+        fake_running = RunningTemplate(
+            run_id="run2",
+            template_path=app_module.Path(target),
+            log_dir=log_dir,
+            process=fake_process,
+            started_at=100.0,
+        )
+        monkeypatch.setattr(app_module.template_runner, "get", lambda rid: fake_running)
+        session = {
+            "project": "newproj",
+            "session_id": "s1",
+            "file_path": str(log_dir / "s1.fn"),
+            "file_mtime": 200.0,
+        }
+        monkeypatch.setattr(
+            app_module.scanner,
+            "get_all_sessions",
+            lambda include_archived=True: [session],
+        )
+
+        resp = templates_client.get("/api/templates/run/run2/status")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body == {"status": "found", "project": "newproj", "session_id": "s1"}
+
+    def test_ignores_sessions_older_than_launch(
+        self, templates_client, templates_registry_with_entries, monkeypatch, tmp_path
+    ):
+        import fenn.dashboard.app as app_module
+
+        log_dir = tmp_path / "logger"
+        log_dir.mkdir()
+        target = templates_registry_with_entries.list_templates()[0]["path"]
+        fake_process = type("FakeProcess", (), {"pid": 1, "poll": lambda self: None})()
+        fake_running = RunningTemplate(
+            run_id="run3",
+            template_path=app_module.Path(target),
+            log_dir=log_dir,
+            process=fake_process,
+            started_at=500.0,
+        )
+        monkeypatch.setattr(app_module.template_runner, "get", lambda rid: fake_running)
+        stale_session = {
+            "project": "oldproj",
+            "session_id": "old1",
+            "file_path": str(log_dir / "old1.fn"),
+            "file_mtime": 100.0,  # before started_at
+        }
+        monkeypatch.setattr(
+            app_module.scanner,
+            "get_all_sessions",
+            lambda include_archived=True: [stale_session],
+        )
+
+        resp = templates_client.get("/api/templates/run/run3/status")
+        assert resp.get_json()["status"] == "pending"
+
+    def test_ignores_sessions_outside_log_dir(
+        self, templates_client, templates_registry_with_entries, monkeypatch, tmp_path
+    ):
+        import fenn.dashboard.app as app_module
+
+        log_dir = tmp_path / "logger"
+        log_dir.mkdir()
+        other_dir = tmp_path / "unrelated"
+        other_dir.mkdir()
+        target = templates_registry_with_entries.list_templates()[0]["path"]
+        fake_process = type("FakeProcess", (), {"pid": 1, "poll": lambda self: None})()
+        fake_running = RunningTemplate(
+            run_id="run4",
+            template_path=app_module.Path(target),
+            log_dir=log_dir,
+            process=fake_process,
+            started_at=0.0,
+        )
+        monkeypatch.setattr(app_module.template_runner, "get", lambda rid: fake_running)
+        unrelated_session = {
+            "project": "other",
+            "session_id": "o1",
+            "file_path": str(other_dir / "o1.fn"),
+            "file_mtime": 999.0,
+        }
+        monkeypatch.setattr(
+            app_module.scanner,
+            "get_all_sessions",
+            lambda include_archived=True: [unrelated_session],
+        )
+
+        resp = templates_client.get("/api/templates/run/run4/status")
+        assert resp.get_json()["status"] == "pending"
+
+    def test_failed_when_process_exited_nonzero(
+        self, templates_client, templates_registry_with_entries, monkeypatch
+    ):
+        import fenn.dashboard.app as app_module
+
+        target = templates_registry_with_entries.list_templates()[0]["path"]
+        fake_process = type(
+            "FakeProcess",
+            (),
+            {
+                "pid": 1,
+                "poll": lambda self: 1,
+                "communicate": lambda self, timeout=None: ("", "boom traceback"),
+            },
+        )()
+        fake_running = RunningTemplate(
+            run_id="run5",
+            template_path=app_module.Path(target),
+            log_dir=app_module.Path(target) / "logger",
+            process=fake_process,
+            started_at=0.0,
+        )
+        monkeypatch.setattr(app_module.template_runner, "get", lambda rid: fake_running)
+
+        resp = templates_client.get("/api/templates/run/run5/status")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["status"] == "failed"
+        assert body["exit_code"] == 1
+        assert "boom traceback" in body["error"]
+
+    def test_requires_authentication(self, templates_client_no_auth):
+        resp = templates_client_no_auth.get("/api/templates/run/anything/status")
+        assert resp.status_code == 302
+        assert "/connect" in resp.headers["Location"]

--- a/tests/unit/dashboard/test_runner.py
+++ b/tests/unit/dashboard/test_runner.py
@@ -29,8 +29,9 @@ def scanner(tmp_path, monkeypatch):
 
 @pytest.fixture()
 def runner():
-    # Tiny grace period keeps unit tests fast.
-    return TemplateRunner(startup_grace_s=0.1)
+    # Windows process spawn is slower than fork()-based platforms; keep
+    # enough headroom to reliably catch immediate crashes there.
+    return TemplateRunner(startup_grace_s=0.4)
 
 
 class TestReadLoggerDir:


### PR DESCRIPTION
Fixes: #268 

## Changes
* Added `GET /api/templates/run/<run_id>/status` in `dashboard/app.py` — polls a launch by `run_id` and returns `{"status": "pending"}`, `{"status": "found", "project", "session_id"}`, or `{"status": "failed", "exit_code", "error"}`, matching newly created sessions to the launch by checking that the session's `.fn` file lives under the run's `log_dir` and has an `file_mtime` at or after the run's `started_at`.
* Added a **Run** button to the Templates page (`templates.html`) for each locally pulled template, with an inline feedback area for launch/poll errors.
* Added client-side interaction in `app.js`: clicking Run calls `POST /api/templates/run`, then polls the new status endpoint every second (30s timeout) until it resolves, and redirects to the existing `/session/<project>/<session_id>` page on success.
* Startup failures (non-zero exit before any session file appears) are now shown inline next to the Run button instead of silently failing.
* Added `TestApiTemplateRunStatus` to `test_api.py`, covering unknown `run_id` (404), pending state, successful match, sessions outside the log dir or older than the launch being ignored, and the failed-process case.

## Notes
* While testing this end-to-end on Windows, found `TemplateRunner.launch()` was spawning templates with a bare `"python"` instead of `sys.executable`, so launched templates ran in a different interpreter than the dashboard and couldn't import packages (e.g. `fenn`) only installed there. Fixed as part of this PR since the Run button surfaced it immediately.
* Also replaced the `time.sleep(startup_grace_s)` + `poll()` startup-crash check in `runner.py` with `process.wait(timeout=startup_grace_s)` — functionally equivalent on fast crashes, but returns as soon as the process exits rather than always blocking the full grace window, and holds up better on Windows where process spawn latency alone could exceed the old fixed sleep.
* Bumped `startup_grace_s` in the `test_runner.py` `runner` fixture from `0.1` to `0.4` — the tighter value was flaky on Windows for the same spawn-latency reason, causing `test_immediate_crash_raises_with_stderr` and `test_crash_does_not_register_log_dir` to intermittently miss the crash.
* Run→session matching relies on `log_dir` + `file_mtime`, since nothing in `RunningTemplate` currently threads a `run_id` through to the written `.fn` file. Fine for the common one-session-per-launch case; a template that spawns multiple sessions into the same `log_dir` within the same launch could resolve ambiguously (picks the newest). Flagging in case that's a real scenario worth tagging log lines with `run_id` for.