### PR TITLE
Fix case-sensitive extension matching in load_documents()

### DIFF
--- a/fenn/agents/rag/loader.py
+++ b/fenn/agents/rag/loader.py
@@ -75,7 +75,7 @@ def load_documents(source):
     elif path.is_dir():
         found = list(path.rglob("*"))
         supported = [
-            f for f in found if f.is_file() and f.suffix in SUPPORTED_EXTENSIONS
+            f for f in found if f.is_file() and f.suffix.lower() in SUPPORTED_EXTENSIONS
         ]
         if not supported:
             logger.warning(f"[cofone] warning: no supported files found in {path}")

--- a/tests/unit/agents/test_rag_components.py
+++ b/tests/unit/agents/test_rag_components.py
@@ -165,6 +165,13 @@ class TestLoadDocuments:
         docs = load_documents(str(tmp_path))
         assert len(docs) == 2
 
+    def test_loads_uppercase_extension(self, tmp_path):
+        (tmp_path / "UPPER.TXT").write_text("upper", encoding="utf-8")
+
+        docs = load_documents(str(tmp_path))
+
+        assert docs == ["upper"]
+
     def test_skips_unsupported_extensions(self, tmp_path):
         (tmp_path / "image.png").write_bytes(b"\x89PNG")
         (tmp_path / "doc.txt").write_text("valid", encoding="utf-8")


### PR DESCRIPTION
## Summary

When scanning directories, `load_documents()` compares file extensions case-sensitively against `SUPPORTED_EXTENSIONS`.

As a result, supported files with uppercase extensions (for example `README.TXT`) are skipped even though the corresponding lowercase extensions are supported.

This PR normalizes the file suffix with `.lower()` before checking membership in `SUPPORTED_EXTENSIONS` and adds a regression test to prevent future regressions.

## Changes

- Normalize file suffixes using `f.suffix.lower()`
- Add a regression test covering uppercase supported extensions

## Testing

- Verified the regression test fails before the fix
- Verified the regression test passes after the fix
- Ran the agents unit test suite:

```
284 passed, 1 skipped
```

Closes #274