### PR TITLE
fix: [#285] correct RAG optional-dependency install instructions (cofone -> fenn[rag-*])

### DIFF
--- a/fenn/agents/rag/loader.py
+++ b/fenn/agents/rag/loader.py
@@ -104,7 +104,7 @@ def _read_file(path):
 def _read_pdf(path):
     """
     Extract text from a PDF file using pypdf.
-    Requires: pip install "cofone[pdf]"  or  pip install pypdf
+    Requires: pip install "fenn[rag-pdf]"  or  pip install pypdf
     """
     try:
         import pypdf
@@ -120,7 +120,7 @@ def _read_pdf(path):
     except ImportError:
         raise ImportError(
             "[cofone] pypdf not installed.\n"
-            'Run: pip install "cofone[pdf]"  or  pip install pypdf'
+            'Run: pip install "fenn[rag-pdf]"  or  pip install pypdf'
         )
 
 
@@ -171,7 +171,7 @@ def _load_wikipedia(url):
     """
     Fetch a Wikipedia article's full text using the wikipedia package.
     Automatically detects language from the URL subdomain.
-    Requires: pip install "cofone[web]"  or  pip install wikipedia
+    Requires: pip install "fenn[rag-web]"  or  pip install wikipedia
     """
     try:
         import re
@@ -198,7 +198,7 @@ def _load_wikipedia(url):
     except ImportError:
         raise ImportError(
             "[cofone] wikipedia package not installed.\n"
-            'Run: pip install "cofone[web]"  or  pip install wikipedia'
+            'Run: pip install "fenn[rag-web]"  or  pip install wikipedia'
         )
     except Exception as e:
         raise ValueError(f"[cofone] Wikipedia error for '{url}': {e}") from e
@@ -209,7 +209,7 @@ def _load_youtube(url):
     Fetch a YouTube video's transcript/subtitles.
     Language priority: English first, then Italian, then any available.
     Auto-generated captions are supported.
-    Requires: pip install "cofone[web]"  or  pip install youtube-transcript-api
+    Requires: pip install "fenn[rag-web]"  or  pip install youtube-transcript-api
     Supports youtube-transcript-api >= 0.6.0 and >= 0.7.0 (dual fallback).
     """
     try:
@@ -251,5 +251,5 @@ def _load_youtube(url):
     except ImportError:
         raise ImportError(
             "[cofone] youtube-transcript-api not installed.\n"
-            'Run: pip install "cofone[web]"  or  pip install youtube-transcript-api'
+            'Run: pip install "fenn[rag-web]"  or  pip install youtube-transcript-api'
         )

--- a/fenn/agents/rag/rag.py
+++ b/fenn/agents/rag/rag.py
@@ -42,7 +42,7 @@ class RAG:
 
     faiss : bool, optional
         If True, uses FAISS semantic vector search instead of BM25 keyword
-        search. Requires `pip install "cofone[faiss]"`. Default: False.
+        search. Requires `pip install "fenn[rag-faiss]"`. Default: False.
 
     embedding_provider : str, optional
         Provider for text embeddings (used only when faiss=True).

--- a/fenn/agents/rag/retriever.py
+++ b/fenn/agents/rag/retriever.py
@@ -135,7 +135,7 @@ class Retriever:
         except ImportError:
             raise ImportError(
                 "[cofone] sentence-transformers not installed.\n"
-                'Run: pip install "cofone[faiss]"  or  pip install sentence-transformers'
+                'Run: pip install "fenn[rag-faiss]"  or  pip install sentence-transformers'
             )
 
     def _embed_openai_compat(self, texts):
@@ -279,7 +279,7 @@ class Retriever:
 
         if sys.modules.get("faiss") is None:
             raise ImportError(
-                '[cofone] faiss-cpu not installed.\nRun: pip install "cofone[faiss]"'
+                '[cofone] faiss-cpu not installed.\nRun: pip install "fenn[rag-faiss]"'
             )
         mod = sys.modules[__name__]
         faiss_mod = getattr(mod, "faiss", None)
@@ -290,7 +290,7 @@ class Retriever:
                 setattr(mod, "faiss", faiss_mod)
             except ImportError:
                 raise ImportError(
-                    '[cofone] faiss-cpu not installed.\nRun: pip install "cofone[faiss]"'
+                    '[cofone] faiss-cpu not installed.\nRun: pip install "fenn[rag-faiss]"'
                 )
         return faiss_mod
 


### PR DESCRIPTION
## What
The RAG modules told users to `pip install "cofone[pdf]"` (and `[web]`, `[faiss]`) in ImportError messages and docstrings. Corrected to the real distribution and extras: `fenn[rag-pdf]`, `fenn[rag-web]`, `fenn[rag-faiss]`.

## Why
`cofone` is not a valid distribution and the extras are named `rag-*` in `pyproject.toml`, so the previous commands fail with `No matching distribution found`.

## Scope
10 strings across `fenn/agents/rag/loader.py`, `retriever.py`, `rag.py`. Left the `[cofone]` log prefixes untouched (separate concern — happy to follow up).

## Testing
`ruff check` and `ruff format --check` pass; no tests referenced these strings.

Closes #285