### PR TITLE
 refactor[#281]: `whenever` migration - replace stdlib `datetime` with `whenever` across `fenn`

### DIFF
--- a/fenn/cli/pull.py
+++ b/fenn/cli/pull.py
@@ -8,8 +8,8 @@ from pathlib import Path
 
 import requests
 from colorama import Fore, Style
+from whenever import Instant
 
-from fenn.cli.utils import _isoformat_utc_now
 from fenn.dashboard.templates_registry import TemplateEntry, TemplatesRegistry
 from fenn.exceptions import NetworkError, TemplateError, TemplateNotFoundError
 from fenn.logging import logger
@@ -248,7 +248,9 @@ def _register_pulled_template(template_name: str, target_dir: Path) -> None:
                 name=target_dir.name,
                 path=str(target_dir),
                 source_template=template_name,
-                pulled_at=_isoformat_utc_now(),
+                pulled_at=Instant.now()
+                .to_fixed_offset(0)
+                .format_iso(unit="microsecond"),
             )
         )
     except Exception as exc:

--- a/fenn/cli/pull.py
+++ b/fenn/cli/pull.py
@@ -4,12 +4,12 @@ import subprocess
 import sys
 import tempfile
 import zipfile
-from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
 from colorama import Fore, Style
 
+from fenn.cli.utils import _isoformat_utc_now
 from fenn.dashboard.templates_registry import TemplateEntry, TemplatesRegistry
 from fenn.exceptions import NetworkError, TemplateError, TemplateNotFoundError
 from fenn.logging import logger
@@ -248,7 +248,7 @@ def _register_pulled_template(template_name: str, target_dir: Path) -> None:
                 name=target_dir.name,
                 path=str(target_dir),
                 source_template=template_name,
-                pulled_at=datetime.now(timezone.utc).isoformat(),
+                pulled_at=_isoformat_utc_now(),
             )
         )
     except Exception as exc:

--- a/fenn/cli/utils.py
+++ b/fenn/cli/utils.py
@@ -1,7 +1,0 @@
-from pathlib import Path
-
-
-def copy_template(source: Path, destination: Path) -> None:
-    with open(source, "r") as f:
-        template = f.read()
-    destination.write_text(template)

--- a/fenn/cli/utils.py
+++ b/fenn/cli/utils.py
@@ -1,19 +1,7 @@
 from pathlib import Path
 
-from whenever import Instant
-
 
 def copy_template(source: Path, destination: Path) -> None:
     with open(source, "r") as f:
         template = f.read()
     destination.write_text(template)
-
-
-def _isoformat_utc_now() -> str:
-    """Return the current UTC time in ISO 8601 format with microseconds and a +00:00 offset using `whenever`."""
-    offset_dt = Instant.now().to_fixed_offset(0)
-    microsecond = offset_dt.nanosecond // 1000
-    base = offset_dt.format("YYYY-MM-DD'T'hh:mm:ss")
-    if microsecond:
-        base += f".{microsecond:06d}"
-    return base + "+00:00"

--- a/fenn/cli/utils.py
+++ b/fenn/cli/utils.py
@@ -1,7 +1,19 @@
 from pathlib import Path
 
+from whenever import Instant
+
 
 def copy_template(source: Path, destination: Path) -> None:
     with open(source, "r") as f:
         template = f.read()
     destination.write_text(template)
+
+
+def _isoformat_utc_now() -> str:
+    """Return the current UTC time in ISO 8601 format with microseconds and a +00:00 offset using `whenever`."""
+    offset_dt = Instant.now().to_fixed_offset(0)
+    microsecond = offset_dt.nanosecond // 1000
+    base = offset_dt.format("YYYY-MM-DD'T'hh:mm:ss")
+    if microsecond:
+        base += f".{microsecond:06d}"
+    return base + "+00:00"

--- a/fenn/dashboard/app.py
+++ b/fenn/dashboard/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 import secrets
-from datetime import datetime, timedelta
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlencode
@@ -25,6 +25,7 @@ from flask import (
 )
 from flask_wtf.csrf import CSRFError, CSRFProtect
 from werkzeug.exceptions import HTTPException
+from whenever import PlainDateTime
 
 from fenn.cli.list import get_available_templates
 from fenn.cli.pull import pull_template
@@ -572,8 +573,8 @@ def api_sessions() -> tuple[Response, int] | Response:
         started_after_raw = request.args.get("started_after") or None
         if started_after_raw is not None:
             try:
-                started_after = datetime.strptime(
-                    started_after_raw, "%Y-%m-%d %H:%M:%S"
+                started_after = PlainDateTime.parse(
+                    started_after_raw, format="YYYY-MM-DD hh:mm:ss"
                 )
             except ValueError:
                 raise _ApiBadRequest(
@@ -585,8 +586,8 @@ def api_sessions() -> tuple[Response, int] | Response:
         started_before_raw = request.args.get("started_before") or None
         if started_before_raw is not None:
             try:
-                started_before = datetime.strptime(
-                    started_before_raw, "%Y-%m-%d %H:%M:%S"
+                started_before = PlainDateTime.parse(
+                    started_before_raw, format="YYYY-MM-DD hh:mm:ss"
                 )
             except ValueError:
                 raise _ApiBadRequest(

--- a/fenn/dashboard/scanner.py
+++ b/fenn/dashboard/scanner.py
@@ -3,10 +3,11 @@
 import json
 import os
 import time
-from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 from xml.etree import ElementTree
+
+from whenever import PlainDateTime
 
 from fenn.dashboard.types import (
     LogEntry,
@@ -540,8 +541,8 @@ class FennScanner:
         project: str | None = None,
         status: str | None = None,
         include_archived: bool = False,
-        started_after: datetime | None = None,
-        started_before: datetime | None = None,
+        started_after: PlainDateTime | None = None,
+        started_before: PlainDateTime | None = None,
         limit: int = 20,
         offset: int = 0,
         sort: str = "-started",
@@ -587,7 +588,7 @@ class FennScanner:
                     if not raw:
                         continue
                     try:
-                        started = datetime.strptime(raw, "%Y-%m-%d %H:%M:%S")
+                        started = PlainDateTime.parse(raw, format="YYYY-MM-DD hh:mm:ss")
                     except (ValueError, TypeError):
                         continue
                     if started_after is not None and started < started_after:

--- a/fenn/logging.py
+++ b/fenn/logging.py
@@ -2,21 +2,27 @@ import builtins
 import logging
 import re
 from collections.abc import MutableMapping
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from colorama import Fore, Style
 from rich.console import Console
 from rich.table import Table
+from whenever import Instant, PlainDateTime
 
 console: Console = Console()
 
 _ansi_escape: re.Pattern[str] = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+_SPACE_SEP_PATTERN = "YYYY-MM-DD hh:mm:ss"
+
+
+def _now_local() -> PlainDateTime:
+    """Returns the current local time as a PlainDateTime object, with nanoseconds set to zero using `whenever`."""
+    return Instant.now().to_system_tz().to_plain().replace(nanosecond=0)
 
 
 class XmlMixin:
-    _started_at: datetime
+    _started_at: PlainDateTime
     fn_file: Path
 
     def _write_config_xml(
@@ -57,22 +63,30 @@ class XmlMixin:
             f.write(
                 f'<fenn-log project="{self._escape(args["project"])}" '
                 f'session_id="{self._escape(args["session_id"])}" '
-                f'started="{self._started_at}">\n'
+                f'started="{self._started_at.format(_SPACE_SEP_PATTERN)}">\n'
             )
 
     def _write_entry(self, record: logging.LogRecord, file_path: Path) -> None:
-        ts = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        ts = Instant.from_timestamp(record.created)
         clean_message = self._escape(_ansi_escape.sub("", record.getMessage()))
         with open(file_path, "a", encoding="utf-8") as f:
             f.write(
-                f'  <entry ts="{ts.strftime("%Y-%m-%d %H:%M:%S")}" kind="user" '
+                f'  <entry ts="{ts.format(_SPACE_SEP_PATTERN)}" kind="user" '
                 f'level="{self._escape(record.levelname)}">{clean_message}</entry>\n'
             )
 
-    def _write_stop_info(self, started_at: datetime) -> None:
-        ended_at = datetime.now().replace(microsecond=0)
-        ended = ended_at.isoformat(" ")
-        duration_s = int((ended_at - started_at).total_seconds()) if started_at else 0
+    def _write_stop_info(self, started_at: PlainDateTime) -> None:
+        ended_at = _now_local()
+        ended = ended_at.format(_SPACE_SEP_PATTERN)
+        duration_s = (
+            int(
+                ended_at.difference(started_at, naive_arithmetic_ok=True).total(
+                    "seconds"
+                )
+            )
+            if started_at
+            else 0
+        )
 
         with open(self.fn_file, "a", encoding="utf-8") as f:
             f.write(
@@ -88,12 +102,12 @@ class FennHandler(XmlMixin, logging.Handler):
     _fn_xml: Path | None
 
     def __init__(self, level: int = 0) -> None:
-        self._started_at = datetime.now().replace(microsecond=0)
+        self._started_at = _now_local()
         self._log_file = None
         self._fn_xml = None
         super().__init__(level)
 
-    def configure(self, args: dict[str, Any], started_at: datetime) -> None:
+    def configure(self, args: dict[str, Any], started_at: PlainDateTime) -> None:
         log_root = Path(args["logger"]["dir"])
         log_dir = log_root / Path(args["project"])
         log_filename = f"{args['session_id']}.log"
@@ -108,11 +122,11 @@ class FennHandler(XmlMixin, logging.Handler):
     ) -> None:
         if self._log_file is None:
             return
-        ts = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        ts = Instant.from_timestamp(record.created)
         clean_message = _ansi_escape.sub("", record.getMessage())
         with open(self._log_file, "a", encoding="utf-8") as f:
             f.write(
-                f"[{ts.strftime('%Y-%m-%d %H:%M:%S')}] {record.levelname} | {clean_message}\n"
+                f"[{ts.format(_SPACE_SEP_PATTERN)}] {record.levelname} | {clean_message}\n"
             )
 
     def _write_to_console(
@@ -144,14 +158,14 @@ class FennHandler(XmlMixin, logging.Handler):
 
 
 class FennLogger(XmlMixin, logging.LoggerAdapter):
-    _started_at: datetime
+    _started_at: PlainDateTime
     handler: "FennHandler"
     fn_file: Path
     txt_file: Path
 
     def __init__(self, logger: logging.Logger, handler: "FennHandler") -> None:
         super().__init__(logger, {})
-        self._started_at = datetime.now().replace(microsecond=0)
+        self._started_at = _now_local()
         self.handler = handler
 
     def write_config(self, args: dict[str, Any], config_file: Path) -> None:
@@ -229,8 +243,8 @@ class FennLogger(XmlMixin, logging.LoggerAdapter):
     ) -> None:
         table = Table(title="")
         table.add_column(f"Configuration file {config_file} loaded", style="", width=80)
-        timestamp_dt = datetime.now().replace(microsecond=0)
-        timestamp = timestamp_dt.isoformat(" ")
+        timestamp_dt = _now_local()
+        timestamp = timestamp_dt.format(_SPACE_SEP_PATTERN)
         for k, v in flat_config.items():
             colored_parts = self._get_colored_parts(key=k)
             table.add_row(f"{'/'.join(colored_parts)}: {v}")

--- a/fenn/reproducibility.py
+++ b/fenn/reproducibility.py
@@ -1,8 +1,8 @@
 import random
 import secrets
-from datetime import datetime
 
 import numpy as np
+from whenever import Instant
 
 
 def set_seed(seed: int) -> None:
@@ -29,7 +29,7 @@ def set_seed(seed: int) -> None:
 
 def generate_session_id() -> str:
 
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M")
+    timestamp = Instant.now().to_system_tz().to_plain().format("YYYYMMDD_hhmm")
 
     # A curated list of "beautiful" words
     # adjectives = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
   "python-dotenv>=1.2.2",
   "faker>=40.8.0",
   "torchvision>=0.25.0",
+  "whenever>=0.10.3",
 ]
 
 requires-python = ">=3.11"

--- a/tests/unit/test_reproducibility.py
+++ b/tests/unit/test_reproducibility.py
@@ -104,12 +104,12 @@ class TestGenerateSessionId:
         )
 
     def test_timestamp_prefix_is_valid_date(self):
-        from datetime import datetime
+        from whenever import PlainDateTime
 
         session_id = generate_session_id()
         timestamp_part = "_".join(session_id.split("_")[:2])
-        # Should parse as a valid datetime
-        parsed = datetime.strptime(timestamp_part, "%Y%m%d_%H%M")
+        # Should parse as a valid date/time
+        parsed = PlainDateTime.parse(timestamp_part, format="YYYYMMDD_hhmm")
         assert parsed is not None
 
     def test_hex_suffix_is_four_chars(self):
@@ -132,10 +132,13 @@ class TestGenerateSessionId:
         assert session_id.endswith("_abcd")
 
     def test_timestamp_uses_current_time(self):
-        from datetime import datetime
+        mock_instant = MagicMock()
+        mock_plain = mock_instant.to_system_tz.return_value.to_plain.return_value
+        mock_plain.format.return_value = "20240615_0930"
 
-        fake_now = datetime(2024, 6, 15, 9, 30)
-        with patch("fenn.reproducibility.datetime") as mock_dt:
-            mock_dt.now.return_value = fake_now
+        with patch("fenn.reproducibility.Instant") as mock_instant_cls:
+            mock_instant_cls.now.return_value = mock_instant
             session_id = generate_session_id()
+
+        mock_plain.format.assert_called_once_with("YYYYMMDD_hhmm")
         assert session_id.startswith("20240615_0930")


### PR DESCRIPTION
Fixes: #281 

## Changes
* Migrated all `datetime` usage in `fenn/logging.py`, `fenn/reproducibility.py`, `fenn/cli/pull.py`, `fenn/dashboard/app.py` and `fenn/dashboard/scanner.py` to the `whenever` library.
* Added `whenever>=0.10.3` to the project dependencies in `pyproject.toml`.
* Replaced `datetime.now()` and `datetime.now().replace(microsecond=0)` with `whenever` equivalents using `Instant`/`PlainDateTime` (`Instant.now().to_system_tz().to_plain()`).
* Replaced `datetime.fromtimestamp(ts, tz=timezone.utc)` with `Instant.from_timestamp(ts)` for UTC log-entry timestamps.
* Replaced `datetime.strptime(...)` parsing (used for the session `started` field and the `/api/sessions` `started_after`/`started_before` query parameters) with `PlainDateTime.parse(..., format=...)`.
* Replaced the duration calculation (`(ended_at - started_at).total_seconds()`) with `PlainDateTime.difference(..., naive_arithmetic_ok=True).total("seconds")`.
* Replaced `datetime.now(timezone.utc).isoformat()` in `fenn/cli/pull.py`'s template registry with a small `_isoformat_utc_now()` helper in `cli/utils.py`.

## Notes
* All formatting and parsing calls now use explicit `whenever` pattern strings (such as `"YYYY-MM-DD hh:mm:ss"` and `"YYYYMMDD_hhmm"`) instead of relying on the library’s default string or ISO formatting. This is important because the default output includes a `T` separator and nanosecond precision with a `Z` UTC suffix, which would change the existing on-disk formats. By using explicit patterns, we ensure that all stored strings in `.fn` XML files, `.log` files, the template registry, and session IDs remain exactly byte-for-byte identical to what was produced by the previous standard library implementation.
* The `PERMANENT_SESSION_LIFETIME` setting was intentionally left using the standard library `timedelta` because it is a Flask/Werkzeug configuration value. Flask internally expects a standard `datetime.timedelta` when calculating session expiration. Specifically, `SessionInterface.get_expiration_time` adds `datetime.now(timezone.utc)` to this value, and mixing it with `whenever.TimeDelta` would cause a type error since the two types are incompatible. For this reason, it must remain a standard library `timedelta` and is excluded from the migration.
* The `test_reproducibility.py` test for timestamp behavior was also updated because it previously mocked `fenn.reproducibility.datetime`, which no longer exists after switching to `whenever`. Timestamps are now generated using `Instant`, which is an immutable Rust-backed type and cannot be monkeypatched directly. As a result, the test was adjusted to mock the module-level `Instant` reference instead.