### PR TITLE
ci: [#279] add dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,26 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0


### PR DESCRIPTION
## Summary

- add dependency review for pull requests targeting `main`
- pin actions to immutable commit SHAs
- use least-privilege permissions
- cancel stale workflow runs when a pull request is updated

## Validation

- validated YAML syntax
- ran `zizmor --pedantic .github/workflows/dependency-review.yaml`
- no zizmor findings reported

## Note

The dependency review action requires GitHub's Dependency Graph to be enabled for the repository.

Fixes #279