### PR TITLE
feat(dashboard): [#293] add training metric logging

### DIFF
--- a/fenn/dashboard/scanner.py
+++ b/fenn/dashboard/scanner.py
@@ -362,24 +362,7 @@ class FennScanner:
                 )
             )
 
-        metrics: list[MetricPoint] = []
-        for metric in root.findall("metric"):
-            name = metric.get("name", "")
-            if not name:
-                continue
-            try:
-                step = int(metric.get("step", ""))
-                value = float(metric.get("value", ""))
-            except (ValueError, TypeError):
-                continue
-            metrics.append(
-                MetricPoint(
-                    name=name,
-                    step=step,
-                    value=value,
-                    ts=metric.get("ts", ""),
-                )
-            )
+        metrics = FennScanner._get_metrics(root)
 
         # Timing from <meta>
         ended: str | None = None
@@ -413,6 +396,28 @@ class FennScanner:
             file_size=stat.st_size,
             file_mtime=stat.st_mtime,
         )
+
+    @staticmethod
+    def _get_metrics(root: ElementTree.Element) -> list[MetricPoint]:
+        """Parse <metric> elements into MetricPoint entries.
+
+        Malformed step/value attributes are skipped rather than raising,
+        mirroring the tolerant handling used for duration_s elsewhere.
+        """
+        metrics = []
+        for metric in root.findall("metric"):
+            name = metric.get("name", "")
+            if not name:
+                continue
+            try:
+                step = int(metric.get("step", ""))
+                value = float(metric.get("value", ""))
+            except (ValueError, TypeError):
+                continue
+            metrics.append(
+                MetricPoint(name=name, step=step, value=value, ts=metric.get("ts", ""))
+            )
+        return metrics
 
     @staticmethod
     def _refresh_running_status(parsed: SessionData, mtime: float) -> SessionData:

--- a/fenn/dashboard/scanner.py
+++ b/fenn/dashboard/scanner.py
@@ -11,6 +11,7 @@ from whenever import PlainDateTime
 
 from fenn.dashboard.types import (
     LogEntry,
+    MetricPoint,
     OverviewPayload,
     ProjectPayload,
     ProjectStats,
@@ -361,6 +362,25 @@ class FennScanner:
                 )
             )
 
+        metrics: list[MetricPoint] = []
+        for metric in root.findall("metric"):
+            name = metric.get("name", "")
+            if not name:
+                continue
+            try:
+                step = int(metric.get("step", ""))
+                value = float(metric.get("value", ""))
+            except (ValueError, TypeError):
+                continue
+            metrics.append(
+                MetricPoint(
+                    name=name,
+                    step=step,
+                    value=value,
+                    ts=metric.get("ts", ""),
+                )
+            )
+
         # Timing from <meta>
         ended: str | None = None
         duration_s: int | None = None
@@ -385,6 +405,7 @@ class FennScanner:
             status=status,
             config=config,
             entries=entries,
+            metrics=metrics,
             entry_count=len(entries),
             warning_count=warnings,
             exception_count=exceptions,
@@ -609,12 +630,17 @@ class FennScanner:
 
         total = len(sessions)
         items = sessions[offset : offset + limit]
-        # Strip the heavy 'entries' list and 'config' from the listing payload — clients
-        # that need per-entry data fetch the single-session endpoint.
+        # Strip the heavy 'entries' list, 'config', and 'metrics' from the listing
+        # payload — clients that need per-entry/metric data fetch the single-session
+        # endpoint.
         slim = [
             cast(
                 SessionListItem,
-                {k: v for k, v in s.items() if k not in ("entries", "config")},
+                {
+                    k: v
+                    for k, v in s.items()
+                    if k not in ("entries", "config", "metrics")
+                },
             )
             for s in items
         ]

--- a/fenn/dashboard/types.py
+++ b/fenn/dashboard/types.py
@@ -14,6 +14,15 @@ class LogEntry(TypedDict):
     message: str
 
 
+class MetricPoint(TypedDict):
+    """Single XML <metric> entry from a Fenn session"""
+
+    name: str
+    step: int
+    value: float
+    ts: str
+
+
 class ProjectStats(TypedDict):
     """Aggregated statistics for a project."""
 
@@ -40,6 +49,7 @@ class SessionData(TypedDict):
 
     config: Dict[str, str]
     entries: List[LogEntry]
+    metrics: List[MetricPoint]
 
     entry_count: int
     warning_count: int
@@ -121,6 +131,7 @@ class SessionPagePayload(TypedDict):
 
     config: Dict[str, str]
     entries: List[LogEntry]
+    metrics: List[MetricPoint]
 
     entry_count: int
     warning_count: int

--- a/fenn/logging.py
+++ b/fenn/logging.py
@@ -189,8 +189,7 @@ class FennLogger(XmlMixin, logging.LoggerAdapter):
         `name` accepts any string and is persisted as-is (e.g. "train_loss",
         "val_loss", "acc" - the values fenn's built-in trainers emit).
         """
-        fn_file = getattr(self, "fn_file", None)
-        if fn_file is None:
+        if getattr(self, "fn_file", None) is None:
             return
         self._write_metric(name=name, value=value, step=step, file_path=self.fn_file)
 

--- a/fenn/logging.py
+++ b/fenn/logging.py
@@ -75,6 +75,17 @@ class XmlMixin:
                 f'level="{self._escape(record.levelname)}">{clean_message}</entry>\n'
             )
 
+    def _write_metric(
+        self, name: str, value: float, step: int, file_path: Path
+    ) -> None:
+        ts = _now_local()
+        with open(file_path, "a", encoding="utf-8") as f:
+            f.write(
+                f'  <metric name="{self._escape(name)}" step="{int(step)}" '
+                f'value="{self._escape(str(value))}" '
+                f'ts="{ts.format(_SPACE_SEP_PATTERN)}" />\n'
+            )
+
     def _write_stop_info(self, started_at: PlainDateTime) -> None:
         ended_at = _now_local()
         ended = ended_at.format(_SPACE_SEP_PATTERN)
@@ -171,6 +182,14 @@ class FennLogger(XmlMixin, logging.LoggerAdapter):
     def write_config(self, args: dict[str, Any], config_file: Path) -> None:
         self.handler.configure(args, self._started_at)
         self._create_config(args=args, config_file=config_file)
+
+    def log_metric(self, name: str, value: float, step: int) -> None:
+        """Appends a structured `<metric>` entry to the run's `.fn` file.
+
+        `name` accepts any string and is persisted as-is (e.g. "train_loss",
+        "val_loss", "acc" - the values fenn's built-in trainers emit).
+        """
+        self._write_metric(name=name, value=value, step=step, file_path=self.fn_file)
 
     def close(self) -> None:
         self._write_stop_info(started_at=self._started_at)

--- a/fenn/logging.py
+++ b/fenn/logging.py
@@ -189,6 +189,9 @@ class FennLogger(XmlMixin, logging.LoggerAdapter):
         `name` accepts any string and is persisted as-is (e.g. "train_loss",
         "val_loss", "acc" - the values fenn's built-in trainers emit).
         """
+        fn_file = getattr(self, "fn_file", None)
+        if fn_file is None:
+            return
         self._write_metric(name=name, value=value, step=step, file_path=self.fn_file)
 
     def close(self) -> None:

--- a/fenn/nn/trainers/classification_trainer.py
+++ b/fenn/nn/trainers/classification_trainer.py
@@ -193,6 +193,7 @@ class ClassificationTrainer(Trainer):
                 raise ValueError("train_loader produced 0 batches; cannot train.")
 
             state.train_loss = total_loss / n_batches
+            logger.log_metric("train_loss", state.train_loss, step=epoch)
 
             progress.update(
                 epoch_task,  # pyright: ignore[reportArgumentType]
@@ -272,6 +273,8 @@ class ClassificationTrainer(Trainer):
 
                 state.val_loss = val_total_loss / val_n_batches
                 state.acc = accuracy_score(val_labels, val_predictions)
+                logger.log_metric("val_loss", state.val_loss, step=epoch)
+                logger.log_metric("acc", state.acc, step=epoch)
 
                 if state.val_loss < state.best_val_loss:
                     state.best_val_loss = state.val_loss

--- a/fenn/nn/trainers/lora_trainer.py
+++ b/fenn/nn/trainers/lora_trainer.py
@@ -241,6 +241,7 @@ class LoRATrainer(Trainer):
                 raise ValueError("train_loader produced 0 batches; cannot train.")
 
             state.train_loss = total_loss / n_batches
+            logger.log_metric("train_loss", state.train_loss, step=epoch)
 
             progress.update(
                 epoch_task,  # pyright: ignore[reportArgumentType]
@@ -296,10 +297,12 @@ class LoRATrainer(Trainer):
                     raise ValueError("val_loader produced 0 batches; cannot validate.")
 
                 state.val_loss = val_total_loss / val_n_batches
+                logger.log_metric("val_loss", state.val_loss, step=epoch)
 
                 if all_preds and all_labels:
                     val_acc = accuracy_score(all_labels, all_preds)
                     state.acc = val_acc
+                    logger.log_metric("acc", state.acc, step=epoch)
                     progress.console.print(
                         f"[bold blue]Epoch {epoch}/{epochs}[/bold blue] "
                         f"Train Loss: {state.train_loss:.4f} | "

--- a/fenn/nn/trainers/regression_trainer.py
+++ b/fenn/nn/trainers/regression_trainer.py
@@ -152,6 +152,7 @@ class RegressionTrainer(Trainer):
                 raise ValueError("train_loader produced 0 batches; cannot train.")
 
             state.train_loss = total_loss / n_batches
+            logger.log_metric("train_loss", state.train_loss, step=epoch)
 
             progress.update(
                 epoch_task,  # pyright: ignore[reportArgumentType]
@@ -220,6 +221,8 @@ class RegressionTrainer(Trainer):
 
                 state.val_loss = val_total_loss / val_n_batches
                 state.acc = r2_score(val_labels, val_predictions)
+                logger.log_metric("val_loss", state.val_loss, step=epoch)
+                logger.log_metric("acc", state.acc, step=epoch)
 
                 progress.update(
                     epoch_task,  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
Fixes: #293

## Changes
* Added `FennLogger.log_metric(name: str, value: float, step: int) -> None` to `fenn/logging.py` for structured metric emission during training runs. `name` accepts any string and is persisted as-is (no fixed enum) — the docstring was corrected to reflect this after confirming the actual names fenn's built-in trainers produce (`train_loss`, `val_loss`, `acc`), rather than the originally-assumed `loss`/`metric`/`learning_rate`.
* `log_metric()` no-ops (returns silently) if the logger has not been configured yet — i.e. `write_config()` was never called, so `fn_file` doesn't exist as an attribute. Mirrors the existing tolerance in `FennHandler.emit()` (`if self._fn_xml and self._log_file:`) for unconfigured loggers.
* Added `XmlMixin._write_metric()` to `fenn/logging.py`, appending self-closing `<metric name="..." step="..." value="..." ts="..." />` elements to `.fn` files, using the same atomic-append + escaping pattern as `_write_entry()`.
* Added `MetricPoint` `TypedDict` to `fenn/dashboard/types.py` (`name: str`, `step: int`, `value: float`, `ts: str`).
* Added `metrics: List[MetricPoint]` to `SessionData` and `SessionPagePayload` in `fenn/dashboard/types.py`. Intentionally **not** added to `SessionListItem`.
* Extended `FennScanner._parse_uncached()` in `fenn/dashboard/scanner.py` to parse `<metric>` nodes into `SessionData.metrics`, skipping elements with a missing `name` or non-numeric `step`/`value` rather than raising.
* Wired `log_metric()` calls into `ClassificationTrainer.fit()`, `RegressionTrainer.fit()`, and `LoRATrainer.fit()` (`fenn/nn/trainers/`) so all three trainers emit `train_loss` every epoch, and `val_loss`/`acc` on validation epochs — no user code changes required to get metrics into the dashboard when using these trainers.

## Notes
* No changes were needed in `fenn/dashboard/app.py`. `api_session()` already returns the full parsed session dict via `jsonify(data)`; `api_sessions()` already delegates entirely to `scanner.list_sessions()`, where the strip is implemented.
* Backward compatibility confirmed: `.fn` files with no `<metric>` elements parse with `metrics == []`.