### PR TITLE
feat(dashboard): [#294] render session metric charts

### DIFF
--- a/fenn/dashboard/static/app.js
+++ b/fenn/dashboard/static/app.js
@@ -537,6 +537,120 @@
     });
   });
 
+  // ── Session tabs (Logs / Graphs) ────────────────────────────────────────── //
+
+  const tabNavItems = document.querySelectorAll(".tab-nav-item");
+  if (tabNavItems.length > 0) {
+    tabNavItems.forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const tab = btn.dataset.tab;
+        if (!tab) return;
+        tabNavItems.forEach((b) => {
+          const active = b === btn;
+          b.classList.toggle("active", active);
+          b.setAttribute("aria-selected", String(active));
+        });
+        document.querySelectorAll(".tab-panel").forEach((panel) => {
+          panel.classList.toggle("active", panel.id === `tab-panel-${tab}`);
+        });
+      });
+    });
+  }
+
+  // Renders a simple SVG line chart (axis baseline + polyline) into svgEl.
+  // `points` is an array of {step, value} objects; `colorVar` is a CSS
+  // custom property name (e.g. "--accent") to stroke the line with.
+  function renderLineChart(svgEl, points, colorVar) {
+    if (!svgEl || !points || points.length === 0) return;
+
+    const viewBox = svgEl.viewBox && svgEl.viewBox.baseVal;
+    const width = viewBox && viewBox.width ? viewBox.width : 600;
+    const height = viewBox && viewBox.height ? viewBox.height : 220;
+    const padding = 24;
+
+    const steps = points.map((p) => p.step);
+    const values = points.map((p) => p.value);
+    const minStep = Math.min(...steps);
+    const maxStep = Math.max(...steps);
+    const minVal = Math.min(...values);
+    const maxVal = Math.max(...values);
+    const stepRange = maxStep - minStep || 1;
+    const valRange = maxVal - minVal || 1;
+
+    const xFor = (s) => padding + ((s - minStep) / stepRange) * (width - padding * 2);
+    const yFor = (v) => height - padding - ((v - minVal) / valRange) * (height - padding * 2);
+
+    while (svgEl.firstChild) svgEl.removeChild(svgEl.firstChild);
+
+    const ns = "http://www.w3.org/2000/svg";
+
+    // Baseline axis
+    const axis = document.createElementNS(ns, "line");
+    axis.setAttribute("x1", String(padding));
+    axis.setAttribute("y1", String(height - padding));
+    axis.setAttribute("x2", String(width - padding));
+    axis.setAttribute("y2", String(height - padding));
+    axis.style.stroke = "var(--border)";
+    axis.setAttribute("stroke-width", "1");
+    svgEl.appendChild(axis);
+
+    // Line
+    const polyline = document.createElementNS(ns, "polyline");
+    const coords = points.map((p) => `${xFor(p.step)},${yFor(p.value)}`).join(" ");
+    polyline.setAttribute("points", coords);
+    polyline.setAttribute("fill", "none");
+    polyline.style.stroke = `var(${colorVar || "--accent"})`;
+    polyline.setAttribute("stroke-width", "2");
+    polyline.setAttribute("vector-effect", "non-scaling-stroke");
+    svgEl.appendChild(polyline);
+  }
+
+  // Reads the hidden #session-metrics-data JSON blob, groups points by
+  // metric name, and populates (or hides) each .chart-card accordingly.
+  // Runs once on page load — the "graphs render once status leaves running"
+  // requirement is satisfied by the existing refresh()'s location.reload(),
+  // which re-renders this template (and this script) fresh with updated data.
+  function renderSessionGraphs() {
+    const dataEl = document.getElementById("session-metrics-data");
+    if (!dataEl) return;
+
+    let metrics = [];
+    try {
+      metrics = JSON.parse(dataEl.textContent || "[]");
+    } catch (_err) {
+      metrics = [];
+    }
+
+    const grouped = {};
+    metrics.forEach((m) => {
+      if (!grouped[m.name]) grouped[m.name] = [];
+      grouped[m.name].push(m);
+    });
+    Object.keys(grouped).forEach((name) => {
+      grouped[name].sort((a, b) => a.step - b.step);
+    });
+
+    document.querySelectorAll(".chart-card").forEach((card) => {
+      const metricName = card.dataset.metric;
+      const points = grouped[metricName] || [];
+      const svgEl = card.querySelector(".chart-svg");
+      const emptyEl = card.querySelector(".chart-empty");
+
+      if (points.length > 0) {
+        if (emptyEl) emptyEl.style.display = "none";
+        if (svgEl) {
+          svgEl.style.display = "";
+          renderLineChart(svgEl, points, card.dataset.color);
+        }
+      } else {
+        if (emptyEl) emptyEl.style.display = "";
+        if (svgEl) svgEl.style.display = "none";
+      }
+    });
+  }
+
+  renderSessionGraphs();
+
   // ── Auto-refresh for running sessions ──────────────────────────────────── //
 
   const sessionStatus = document.getElementById("session-status");
@@ -586,6 +700,8 @@
 
           // Status changed (e.g. running → completed/crashed) — full reload
           // because the header badge and meta row need server-side re-render.
+          // This also naturally re-renders the Graphs tab with the now-complete
+          // metrics, since renderSessionGraphs() runs again on the fresh page.
           if (data.status !== "running") {
             location.reload();
             return;

--- a/fenn/dashboard/static/style.css
+++ b/fenn/dashboard/static/style.css
@@ -558,6 +558,54 @@ mark, .log-msg .hl, .log-msg .highlight {
 /* Utility — toggled by app.js to hide filtered-out rows. */
 .log-entry.hidden { display: none; }
 
+/* ── Session tabs (Logs / Graphs) ──────────────────────────────────── */
+.tab-nav {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 20px;
+}
+.tab-nav-item {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-mute);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: .03em;
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: color .15s, border-color .15s;
+}
+.tab-nav-item:hover { color: var(--text); }
+.tab-nav-item.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
+
+/* ── Graphs tab ────────────────────────────────────────────────────── */
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+.chart-card-body { position: relative; }
+.chart-svg {
+  width: 100%;
+  height: 220px;
+  display: block;
+}
+/* Nested inside .card already — drop the dashed box/background so it
+   doesn't double up with the surrounding card. */
+.chart-card .empty {
+  padding: 40px 20px;
+  border: none;
+  background: transparent;
+}
+
 /* ── Empty / 404 ───────────────────────────────────────────────────── */
 .empty {
   text-align: center;
@@ -966,5 +1014,8 @@ mark, .log-msg .hl, .log-msg .highlight {
   }
   .stat-value {
     font-size: 20px;
+  }
+  .chart-svg {
+    height: 160px;
   }
 }

--- a/fenn/dashboard/templates/session.html
+++ b/fenn/dashboard/templates/session.html
@@ -20,6 +20,9 @@
   data-archived="{{ 'true' if archived else 'false' }}"
       style="display:none;"></span>
 
+<!-- Hidden metrics data for the Graphs tab -->
+<script type="application/json" id="session-metrics-data">{{ metrics | tojson }}</script>
+
 <!-- Header -->
 <div class="page-header">
   <span class="page-tag" id="session-display-name-header">{{ display_name or '' }}</span>
@@ -91,57 +94,135 @@
   </div>
 </div>
 
-<!-- Config -->
-{% if config %}
-<div class="card" style="margin-bottom:20px;">
-  <div class="card-header">
-    <span class="card-title">⚙ Configuration</span>
-    <button class="collapsible-btn"
-            data-target="config-body"
-            aria-expanded="true">
-      <span class="arrow">▼</span> collapse
-    </button>
+<!-- Tab navigation -->
+<div class="tab-nav" role="tablist">
+  <button type="button"
+          class="tab-nav-item active"
+          data-tab="logs"
+          role="tab"
+          aria-selected="true">Logs</button>
+  <button type="button"
+          class="tab-nav-item"
+          data-tab="graphs"
+          role="tab"
+          aria-selected="false">Graphs</button>
+</div>
+
+<div id="tab-panel-logs" class="tab-panel active">
+
+  <!-- Config -->
+  {% if config %}
+  <div class="card" style="margin-bottom:20px;">
+    <div class="card-header">
+      <span class="card-title">⚙ Configuration</span>
+      <button class="collapsible-btn"
+              data-target="config-body"
+              aria-expanded="true">
+        <span class="arrow">▼</span> collapse
+      </button>
+    </div>
+    <div id="config-body" class="collapsible-body">
+      <div class="card-body">
+        <div class="config-grid">
+          {% for key, val in config.items() %}
+          <div class="config-item">
+            <span class="config-key">{{ key }}</span>
+            <span class="config-sep">=</span>
+            <span class="config-val">{{ val }}</span>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
   </div>
-  <div id="config-body" class="collapsible-body">
-    <div class="card-body">
-      <div class="config-grid">
-        {% for key, val in config.items() %}
-        <div class="config-item">
-          <span class="config-key">{{ key }}</span>
-          <span class="config-sep">=</span>
-          <span class="config-val">{{ val }}</span>
+  {% endif %}
+
+  <!-- Log entries -->
+  <div class="card">
+    <div class="log-entries">
+      {% if entries %}
+        {% for entry in entries %}
+        <div class="log-entry level-{{ entry.level }} kind-{{ entry.kind }}"
+             data-level="{{ entry.level }}"
+             data-kind="{{ entry.kind }}">
+          <span class="log-ts">{{ entry.ts }}</span>
+          <span class="log-kind">
+            <span class="badge badge-{{ entry.kind }}" style="font-size:10px;">{{ entry.kind }}</span>
+          </span>
+          <span class="log-level">
+            <span class="badge badge-{{ entry.level }}" style="font-size:10px;">{{ entry.level }}</span>
+          </span>
+          <span class="log-msg">{{ entry.message }}</span>
         </div>
         {% endfor %}
+      {% else %}
+      <div class="empty" style="padding:40px 20px;">
+        <div class="empty-title">No log entries</div>
+        <div class="empty-desc">This session has no recorded entries yet.</div>
       </div>
+      {% endif %}
     </div>
   </div>
-</div>
-{% endif %}
 
-<!-- Log entries -->
-<div class="card">
-  <div class="log-entries">
-    {% if entries %}
-      {% for entry in entries %}
-      <div class="log-entry level-{{ entry.level }} kind-{{ entry.kind }}"
-           data-level="{{ entry.level }}"
-           data-kind="{{ entry.kind }}">
-        <span class="log-ts">{{ entry.ts }}</span>
-        <span class="log-kind">
-          <span class="badge badge-{{ entry.kind }}" style="font-size:10px;">{{ entry.kind }}</span>
-        </span>
-        <span class="log-level">
-          <span class="badge badge-{{ entry.level }}" style="font-size:10px;">{{ entry.level }}</span>
-        </span>
-        <span class="log-msg">{{ entry.message }}</span>
+</div>
+
+<div id="tab-panel-graphs" class="tab-panel">
+  <div class="chart-grid">
+
+    <div class="card chart-card" data-metric="train_loss" data-color="--accent">
+      <div class="card-header">
+        <span class="card-title">Train Loss</span>
       </div>
-      {% endfor %}
-    {% else %}
-    <div class="empty" style="padding:40px 20px;">
-      <div class="empty-title">No log entries</div>
-      <div class="empty-desc">This session has no recorded entries yet.</div>
+      <div class="card-body chart-card-body">
+        <svg class="chart-svg" viewBox="0 0 600 220" preserveAspectRatio="none" style="display:none;"></svg>
+        <div class="empty chart-empty">
+          {% if status == 'running' %}
+          <div class="empty-title">Training in progress</div>
+          <div class="empty-desc">Graphs will appear once this session completes.</div>
+          {% else %}
+          <div class="empty-title">No data</div>
+          <div class="empty-desc">No train_loss metrics were recorded for this session.</div>
+          {% endif %}
+        </div>
+      </div>
     </div>
-    {% endif %}
+
+    <div class="card chart-card" data-metric="val_loss" data-color="--warning">
+      <div class="card-header">
+        <span class="card-title">Val Loss</span>
+      </div>
+      <div class="card-body chart-card-body">
+        <svg class="chart-svg" viewBox="0 0 600 220" preserveAspectRatio="none" style="display:none;"></svg>
+        <div class="empty chart-empty">
+          {% if status == 'running' %}
+          <div class="empty-title">Training in progress</div>
+          <div class="empty-desc">Graphs will appear once this session completes.</div>
+          {% else %}
+          <div class="empty-title">No data</div>
+          <div class="empty-desc">No val_loss metrics were recorded for this session.</div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+
+    <div class="card chart-card" data-metric="acc" data-color="--success">
+      <div class="card-header">
+        <span class="card-title">Accuracy</span>
+      </div>
+      <div class="card-body chart-card-body">
+        <svg class="chart-svg" viewBox="0 0 600 220" preserveAspectRatio="none" style="display:none;"></svg>
+        <div class="empty chart-empty">
+          {% if status == 'running' %}
+          <div class="empty-title">Training in progress</div>
+          <div class="empty-desc">Graphs will appear once this session completes.</div>
+          {% else %}
+          <div class="empty-title">No data</div>
+          <div class="empty-desc">No acc metrics were recorded for this session.</div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+
   </div>
 </div>
 


### PR DESCRIPTION
Fixes: #294

## Changes
* Added `.tab-nav` navigation (Logs / Graphs) and wrapped the existing Config + Log-entries cards in a `#tab-panel-logs` container in `fenn/dashboard/templates/session.html`.
* Added `#tab-panel-graphs` with 3 chart cards — **Train Loss / Val Loss / Accuracy** — each an SVG placeholder + empty-state, reusing existing `.card` and `.empty`/`.empty-title`/`.empty-desc` classes rather than introducing new container styling.
* Added a hidden `<script type="application/json" id="session-metrics-data">{{ metrics | tojson }}</script>` blob to the template for JS to consume, matching the existing hidden-data pattern (`#session-status`).
* Added tab-switch click handling in `fenn/dashboard/static/app.js`.
* Added `renderLineChart(svgEl, points, colorVar)` in `app.js` — hand-rolled SVG polyline + baseline axis, no chart library, colors set via `element.style.stroke = "var(--colorVar)"`.
* Added `renderSessionGraphs()` in `app.js` — parses the metrics JSON blob, groups by name, and populates or hides each `.chart-card` on page load.
* Added `.tab-nav`, `.tab-nav-item(.active)`, `.tab-panel(.active)`, `.chart-grid`, `.chart-svg`, `.chart-card .empty` to `fenn/dashboard/static/style.css` — all colors via existing `var(--accent)`/`var(--warning)`/`var(--success)`/`var(--border)` custom properties, no new hardcoded values, no build step.

## Notes
* **No extra polling hook was needed** to satisfy "hook into the existing `refresh()` polling cycle." The existing `refresh()` already does `location.reload()` when `data.status !== 'running'`, which re-serves the template with fresh `metrics` — `renderSessionGraphs()` just runs again naturally on the reloaded page. Left `refresh()` itself untouched.
* Chart color mapping (Train Loss → `--accent`, Val Loss → `--warning`, Accuracy → `--success`) is a design choice via each `.chart-card`'s `data-color` attribute, easy to change without touching JS.
* No new dependencies, no build step — `renderLineChart` is plain DOM/SVG API (`createElementNS`), consistent with the rest of `app.js`.