### PR TITLE
feat(dashboard): [#304] implement per-metric detail pages and endpoint

### DIFF
--- a/fenn/dashboard/app.py
+++ b/fenn/dashboard/app.py
@@ -428,6 +428,25 @@ def session_view(project_name: str, session_id: str) -> str:
     return render_template("session.html", **data)
 
 
+@app.route(
+    "/session/<project_name>/<session_id>/metric/<metric_name>",
+    endpoint="session_metric_detail",
+)
+def session_metric_detail(project_name: str, session_id: str, metric_name: str) -> str:
+    data = scanner.get_session(project_name, session_id)
+    if data is None:
+        abort(404)
+    points = [m for m in data["metrics"] if m["name"] == metric_name]
+    if not points:
+        abort(404)
+    return render_template(
+        "session_metric_detail.html",
+        **data,
+        metric_name=metric_name,
+        metric_points=points,
+    )
+
+
 @app.route("/templates")
 def templates_page() -> str:
     """Return the local templates registry page, listing all templates that have been pulled into a local directory."""

--- a/fenn/dashboard/templates/session.html
+++ b/fenn/dashboard/templates/session.html
@@ -172,6 +172,8 @@
     <div class="card chart-card" data-metric="train_loss" data-color="--accent">
       <div class="card-header">
         <span class="card-title">Train Loss</span>
+        <a href="{{ url_for('session_metric_detail', project_name=project, session_id=session_id, metric_name='train_loss') }}"
+           class="btn btn-sm">View details</a>
       </div>
       <div class="card-body chart-card-body">
         <svg class="chart-svg" viewBox="0 0 600 220" preserveAspectRatio="none" style="display:none;"></svg>
@@ -190,6 +192,8 @@
     <div class="card chart-card" data-metric="val_loss" data-color="--warning">
       <div class="card-header">
         <span class="card-title">Val Loss</span>
+        <a href="{{ url_for('session_metric_detail', project_name=project, session_id=session_id, metric_name='val_loss') }}"
+           class="btn btn-sm">View details</a>
       </div>
       <div class="card-body chart-card-body">
         <svg class="chart-svg" viewBox="0 0 600 220" preserveAspectRatio="none" style="display:none;"></svg>
@@ -208,6 +212,8 @@
     <div class="card chart-card" data-metric="acc" data-color="--success">
       <div class="card-header">
         <span class="card-title">Accuracy</span>
+        <a href="{{ url_for('session_metric_detail', project_name=project, session_id=session_id, metric_name='acc') }}"
+           class="btn btn-sm">View details</a>
       </div>
       <div class="card-body chart-card-body">
         <svg class="chart-svg" viewBox="0 0 600 220" preserveAspectRatio="none" style="display:none;"></svg>

--- a/fenn/dashboard/templates/session_metric_detail.html
+++ b/fenn/dashboard/templates/session_metric_detail.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block title %}{{ metric_name }} — {{ session_id | short_id }}… — {{ project }} — Fenn Dashboard{% endblock %}
+
+{% block breadcrumb %}
+<a href="/">Overview</a>
+<span class="breadcrumb-sep">›</span>
+<a href="/project/{{ project | urlencode }}">{{ project }}</a>
+<span class="breadcrumb-sep">›</span>
+<a href="/session/{{ project | urlencode }}/{{ session_id | urlencode }}">{{ session_id | short_id }}…</a>
+<span class="breadcrumb-sep">›</span>
+<span class="breadcrumb-current">{{ metric_name }}</span>
+{% endblock %}
+
+{% block content %}
+
+<script type="application/json" id="session-metrics-data">{{ metric_points | tojson }}</script>
+
+<div class="page-header">
+  <h1 class="page-title">{{ metric_name }}</h1>
+  <p class="page-subtitle">Session <span class="session-display-name">{{ session_id }}</span></p>
+</div>
+
+<div class="card chart-card" data-metric="{{ metric_name }}" data-color="--accent">
+  <div class="card-header">
+    <span class="card-title">{{ metric_name }}</span>
+  </div>
+  <div class="card-body chart-card-body">
+    <svg class="chart-svg" viewBox="0 0 900 400" preserveAspectRatio="none" style="display:none;"></svg>
+    <div class="empty chart-empty">
+      <div class="empty-title">No data</div>
+      <div class="empty-desc">No {{ metric_name }} metrics were recorded for this session.</div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Fixes: #304 

## Changes
* Added `GET /session/<project_name>/<session_id>/metric/<metric_name>` route (`session_metric_detail`) to `fenn/dashboard/app.py`, reusing `scanner.get_session()` — no scanner or type changes required.
* Route returns 404 when the session doesn't exist, and 404 when no `<metric>` points match `metric_name` for that session (there's no metric registry independent of recorded data, so an unknown name and a known-but-empty name both 404 — matches the acceptance criteria's "unknown metric name" wording).
* Added `fenn/dashboard/templates/session_metric_detail.html`, extending `base.html` with breadcrumb `Overview › <project> › <session> › <metric_name>`, mirroring `session.html`'s `#session-metrics-data` JSON-blob pattern (scoped to the single metric's points instead of the full list) and its `.chart-card`/`chart-svg` markup so existing chart-rendering JS can pick it up unmodified.
* Added a "View details" link to each of the three `.chart-card` headers in `session.html` (`train_loss`, `val_loss`, `acc`), pointing at `url_for('session_metric_detail', ...)`.

## Notes
* No changes to `scanner.py` or `types.py` — `get_session()` already returns the full `metrics` list; filtering by `metric_name` happens in the route.