### PR TITLE
docs: update project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,8 +139,8 @@ fenn = "fenn.cli:main"
 [project.urls]
 "Homepage" = "https://pyfenn.org"
 "Documentation" = "https://pyfenn.org"
-"Source Code" = "https://github.com/blkdmr/fenn"
-"Bug Tracker" = "https://github.com/blkdmr/fenn/issues"
+"Source Code" = "https://github.com/pyfenn/fenn"
+"Bug Tracker" = "https://github.com/pyfenn/fenn/issues"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

- Update the package metadata source and issue tracker URLs from `blkdmr/fenn` to `pyfenn/fenn`, matching the repository and README badges.

## Validation

- Checked the `pyproject.toml` diff.
- Verified the old `blkdmr/fenn` URLs are no longer present in `pyproject.toml`.
