### PR TITLE
fix: correct template list command hint

### DIFF
--- a/fenn/cli/pull.py
+++ b/fenn/cli/pull.py
@@ -285,7 +285,7 @@ def _download_template(template_name: str, target_dir: Path, force: bool) -> Non
         if e.response.status_code == 404:  # ty: ignore[unresolved-attribute]
             raise TemplateNotFoundError(
                 f"Template {Fore.LIGHTYELLOW_EX}{template_name}{Fore.RED} not found. "
-                f"Use {Fore.LIGHTYELLOW_EX}fenn pull --list{Fore.RED} to see available templates, "
+                f"Use {Fore.LIGHTYELLOW_EX}fenn list{Fore.RED} to see available templates, "
                 f"or visit {Fore.CYAN}https://github.com/{TEMPLATES_REPO}{Style.RESET_ALL}"
             )
         raise NetworkError(f"Failed to check template existence: {e}")

--- a/tests/unit/cli/test_pull_command.py
+++ b/tests/unit/cli/test_pull_command.py
@@ -119,6 +119,8 @@ class TestPullCommand:
         captured = capsys.readouterr()
         assert "Template" in captured.out
         assert "nonexistent" in captured.out
+        assert "fenn list" in captured.out
+        assert "fenn pull --list" not in captured.out
 
     def test_pull_network_error_on_check(self, requests_mock, capsys, tmp_path):
         """Test pull with network error during template check."""


### PR DESCRIPTION
## Summary

- Fix the template-not-found error message to suggest `fenn list` instead of the unsupported `fenn pull --list`.
- Add regression assertions so the CLI output keeps pointing users to the valid command.

## Validation

- Ran Python syntax check:
  `python -m py_compile fenn/cli/pull.py tests/unit/cli/test_pull_command.py`

Full pytest was not run locally because this environment does not have pytest installed.
