### PR TITLE
fix(cli): correct template-not-found hint to `fenn list`

### DIFF
--- a/fenn/cli/pull.py
+++ b/fenn/cli/pull.py
@@ -285,7 +285,7 @@ def _download_template(template_name: str, target_dir: Path, force: bool) -> Non
         if e.response.status_code == 404:  # ty: ignore[unresolved-attribute]
             raise TemplateNotFoundError(
                 f"Template {Fore.LIGHTYELLOW_EX}{template_name}{Fore.RED} not found. "
-                f"Use {Fore.LIGHTYELLOW_EX}fenn pull --list{Fore.RED} to see available templates, "
+                f"Use {Fore.LIGHTYELLOW_EX}fenn list{Fore.RED} to see available templates, "
                 f"or visit {Fore.CYAN}https://github.com/{TEMPLATES_REPO}{Style.RESET_ALL}"
             )
         raise NetworkError(f"Failed to check template existence: {e}")

--- a/fenn/experimental/vision/normalize.py
+++ b/fenn/experimental/vision/normalize.py
@@ -106,7 +106,7 @@ def _normalize_0_1(array: np.ndarray) -> np.ndarray:
                 normalized_alpha = alpha_channel / dtype_max
             else:
                 # Float type: if > 1, assume [0, 255] range, else already normalized
-                if alpha_channel.max() > 1.0:
+                if np.max(alpha_channel) > 1.0:
                     normalized_alpha = alpha_channel / 255.0
                 else:
                     normalized_alpha = alpha_channel
@@ -130,7 +130,7 @@ def _normalize_0_1(array: np.ndarray) -> np.ndarray:
                 normalized_alpha = alpha_channel / dtype_max
             else:
                 # Float type: if > 1, assume [0, 255] range, else already normalized
-                if alpha_channel.max() > 1.0:
+                if np.max(alpha_channel) > 1.0:
                     normalized_alpha = alpha_channel / 255.0
                 else:
                     normalized_alpha = alpha_channel
@@ -198,7 +198,7 @@ def _normalize_minus1_1(array: np.ndarray) -> np.ndarray:
                 normalized_alpha = 2.0 * (alpha_channel / dtype_max) - 1.0
             else:
                 # Float type: if > 1, assume [0, 255] range, else already in [0, 1]
-                if alpha_channel.max() > 1.0:
+                if np.max(alpha_channel) > 1.0:
                     normalized_alpha = 2.0 * (alpha_channel / 255.0) - 1.0
                 else:
                     # Already in [0, 1], map to [-1, 1]
@@ -223,7 +223,7 @@ def _normalize_minus1_1(array: np.ndarray) -> np.ndarray:
                 normalized_alpha = 2.0 * (alpha_channel / dtype_max) - 1.0
             else:
                 # Float type: if > 1, assume [0, 255] range, else already in [0, 1]
-                if alpha_channel.max() > 1.0:
+                if np.max(alpha_channel) > 1.0:
                     normalized_alpha = 2.0 * (alpha_channel / 255.0) - 1.0
                 else:
                     # Already in [0, 1], map to [-1, 1]
@@ -290,8 +290,8 @@ def _normalize_imagenet_stats(array: np.ndarray) -> np.ndarray:
             alpha_channel_original = array_float[:, 3:4, ...].copy()
 
         # Auto-normalize only RGB channels to [0, 1] if needed
-        rgb_max = rgb_channels_float.max()
-        rgb_min = rgb_channels_float.min()
+        rgb_max = np.max(rgb_channels_float)
+        rgb_min = np.min(rgb_channels_float)
 
         if rgb_min < 0.0:
             if rgb_max <= 1.0:
@@ -306,8 +306,8 @@ def _normalize_imagenet_stats(array: np.ndarray) -> np.ndarray:
                 rgb_channels_float = rgb_channels_float / 255.0
     else:
         # Auto-normalize entire array to [0, 1] if values are outside expected [0, 1] range
-        array_max = array_float.max()
-        array_min = array_float.min()
+        array_max = np.max(array_float)
+        array_min = np.min(array_float)
 
         if array_min < 0.0:
             # Values are < 0, likely in [-1, 1] range
@@ -341,7 +341,7 @@ def _normalize_imagenet_stats(array: np.ndarray) -> np.ndarray:
                 normalized_alpha = alpha_channel_original / dtype_max
             else:
                 # Float type: if > 1, assume [0, 255] range, else already in [0, 1]
-                if alpha_channel_original.max() > 1.0:
+                if np.max(alpha_channel_original) > 1.0:
                     normalized_alpha = alpha_channel_original / 255.0
                 else:
                     # Already in [0, 1], preserve as-is
@@ -359,7 +359,7 @@ def _normalize_imagenet_stats(array: np.ndarray) -> np.ndarray:
                 normalized_alpha = alpha_channel_original / dtype_max
             else:
                 # Float type: if > 1, assume [0, 255] range, else already in [0, 1]
-                if alpha_channel_original.max() > 1.0:
+                if np.max(alpha_channel_original) > 1.0:
                     normalized_alpha = alpha_channel_original / 255.0
                 else:
                     # Already in [0, 1], preserve as-is
@@ -435,7 +435,7 @@ def _normalize_zscore(array: np.ndarray) -> np.ndarray:
                 normalized_alpha = alpha_channel / dtype_max
             else:
                 # Float type: if > 1, assume [0, 255] range, else already in [0, 1]
-                if alpha_channel.max() > 1.0:
+                if np.max(alpha_channel) > 1.0:
                     normalized_alpha = alpha_channel / 255.0
                 else:
                     # Already in [0, 1], preserve as-is
@@ -459,7 +459,7 @@ def _normalize_zscore(array: np.ndarray) -> np.ndarray:
                 normalized_alpha = alpha_channel / dtype_max
             else:
                 # Float type: if > 1, assume [0, 255] range, else already in [0, 1]
-                if alpha_channel.max() > 1.0:
+                if np.max(alpha_channel) > 1.0:
                     normalized_alpha = alpha_channel / 255.0
                 else:
                     # Already in [0, 1], preserve as-is

--- a/tests/unit/cli/test_pull_command.py
+++ b/tests/unit/cli/test_pull_command.py
@@ -119,6 +119,10 @@ class TestPullCommand:
         captured = capsys.readouterr()
         assert "Template" in captured.out
         assert "nonexistent" in captured.out
+        # The not-found hint must point to the real `fenn list` command,
+        # not the non-existent `fenn pull --list` flag (see issue #312).
+        assert "fenn list" in captured.out
+        assert "fenn pull --list" not in captured.out
 
     def test_pull_network_error_on_check(self, requests_mock, capsys, tmp_path):
         """Test pull with network error during template check."""


### PR DESCRIPTION
## Summary

Fixes #312.

When a user ran `fenn pull <bad-name> ...` for a template that does not exist, the CLI suggested `fenn pull --list`. That flag does not exist on the `pull` subcommand. The correct command for listing templates is `fenn list`.

## Changes

- `fenn/cli/pull.py`: point the template-not-found hint to `fenn list`.
- `tests/unit/cli/test_pull_command.py`: add regression assertions for the corrected hint.
- `fenn/experimental/vision/normalize.py`: replace 12 equivalent NumPy bound-method reductions (`array.max()` / `array.min()`) with `np.max(array)` / `np.min(array)`. These mechanical substitutions resolve the `ty` diagnostics that caused the PR pipeline to fail; no normalization behavior is intentionally changed.

## Scope

The PR is limited to 3 files with 17 additions and 13 deletions. Unrelated dashboard, template-test, normalization-validation, warning-handling, and lockfile changes have been removed.

## Verification

- `pre-commit run --all-files`: passed
- Targeted CLI and normalization tests: 53 passed
- Configured Nox unit session: 918 passed, 7 optional-dependency skips

## Reproduction

Run `fenn pull DOES_NOT_EXIST temp`.

Expected: the response suggests `fenn list`.

Previously observed: the response suggested the nonexistent `fenn pull --list` command.
